### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN rustup component add rustfmt
 RUN cargo build --verbose --release
 
 # our final base
-FROM debian:buster-slim
+FROM rust:1.56
 
 # copy the build artifact from the build stage
 COPY --from=build-sensei /build/target/release/senseid .


### PR DESCRIPTION
Currently the Dockerfile assumes the user has already built the web-admin assets locally and will fail building a fresh clone with:

```
error: proc-macro derive panicked
   --> src/main.rs:235:10
    |
235 | #[derive(RustEmbed)]
    |          ^^^^^^^^^
    |
    = help: message: #[derive(RustEmbed)] folder '/senseid/web-admin/build/' does not exist. cwd: '/senseid'
```

This PR builds the web-admin assets in the Dockerfile.

It also uses debian as the resulting base image which is missing some dynamically linked dependencies from the Rust image:

```
./senseid: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by ./senseid)
```

This PR also swaps out the Debian base image for Rust to resolve that.