### PR TITLE
GitHub actions CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         target:
           # MSVC
-          - i686-pc-windows-msvc
+          #- i686-pc-windows-msvc
           - x86_64-pc-windows-msvc
           # GNU
           # - i686-pc-windows-gnu

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,9 +34,18 @@ jobs:
       matrix:
         platform: [linux-musl]
 
+  build-web-admin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - run: cd web-admin && npm install && CI=false npm run build
+
   windows:
     runs-on: windows-latest
-    needs: install-cross
+    needs: ["install-cross", "build-web-admin"]
     strategy:
       matrix:
         target:
@@ -85,6 +94,7 @@ jobs:
 
   macos:
     runs-on: macos-latest
+    needs: build-web-admin
     strategy:
       matrix:
         target:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,8 @@ on:
 
 name: CD
 env:
-  BIN: sensei
+  CLI: senseicli
+  DAEMON: senseid
 
 jobs:
   # This job downloads and stores `cross` as an artifact, so that it can be
@@ -81,8 +82,10 @@ jobs:
       - run: bash ci/build.bash cargo ${{ matrix.target }} RELEASE
       - run: |
           cd ./target/${{ matrix.target }}/release/
-          7z a "${{ env.BIN }}.zip" "${{ env.BIN }}.exe"
-          mv "${{ env.BIN }}.zip" $GITHUB_WORKSPACE
+          7z a "${{ env.DAEMON }}.zip" "${{ env.DAEMON }}.exe"
+          mv "${{ env.DAEMON }}.zip" $GITHUB_WORKSPACE
+          7z a "${{ env.CLI }}.zip" "${{ env.CLI }}.exe"
+          mv "${{ env.CLI }}.zip" $GITHUB_WORKSPACE
         shell: bash
         # We're using using a fork of `actions/create-release` that detects
         # whether a release is already available or not first.
@@ -99,13 +102,23 @@ jobs:
           prerelease: false
 
       - uses: actions/upload-release-asset@v1
-        id: upload-release-asset
+        id: upload-cli-release-asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.BIN }}.zip
-          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.zip
+          asset_path: ${{ env.CLI }}.zip
+          asset_name: ${{ env.CLI }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1
+        id: upload-daemon-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.DAEMON }}.zip
+          asset_name: ${{ env.DAEMON }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.zip
           asset_content_type: application/zip
 
   macos:
@@ -160,7 +173,9 @@ jobs:
           args: --release --target ${{ matrix.target }}
           use-cross: ${{ matrix.os == 'ubuntu-latest' }}
 
-      - run: tar -czvf ${{ env.BIN }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.BIN }}
+      - run: tar -czvf ${{ env.CLI }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.CLI }}
+      - run: tar -czvf ${{ env.DAEMON }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.DAEMON }}
+
       - uses: XAMPPRocky/create-release@v1.0.2
         id: create_release
         env:
@@ -172,13 +187,23 @@ jobs:
           prerelease: false
 
       - uses: actions/upload-release-asset@v1
-        id: upload-release-asset
+        id: upload-cli-release-asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.BIN }}.tar.gz
-          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
+          asset_path: ${{ env.CLI }}.tar.gz
+          asset_name: ${{ env.CLI }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
+          asset_content_type: application/gzip
+
+      - uses: actions/upload-release-asset@v1
+        id: upload-daemon-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.DAEMON }}.tar.gz
+          asset_name: ${{ env.DAEMON }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
           asset_content_type: application/gzip
 
   linux:
@@ -247,7 +272,10 @@ jobs:
 
       - run: ci/set_rust_version.bash stable ${{ matrix.target }}
       - run: ci/build.bash /tmp/cross ${{ matrix.target }} RELEASE
-      - run: tar -czvf ${{ env.BIN }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.BIN }}
+
+      - run: tar -czvf ${{ env.CLI }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.CLI }}
+      - run: tar -czvf ${{ env.DAEMON }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.DAEMON }}
+
       - uses: XAMPPRocky/create-release@v1.0.2
         id: create_release
         env:
@@ -258,13 +286,24 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload Release Asset
-        id: upload-release-asset
+      - name: Upload CLI Release Asset
+        id: upload-cli-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.BIN }}.tar.gz
-          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
+          asset_path: ${{ env.CLI }}.tar.gz
+          asset_name: ${{ env.CLI }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload Daemon Release Asset
+        id: upload-daemon-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.DAEMON }}.tar.gz
+          asset_name: ${{ env.DAEMON }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,234 @@
+on:
+  push:
+    # # Sequence of patterns matched against refs/tags
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: CD
+env:
+  BIN: sensei
+
+jobs:
+  # This job downloads and stores `cross` as an artifact, so that it can be
+  # re-downloaded across all of the jobs. Currently this copied pasted between
+  # `mean_bean_ci.yml` and `mean_bean_deploy.yml`. Make sure to update both places when making
+  # changes.
+  install-cross:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 50
+      - uses: XAMPPRocky/get-github-release@v1
+        id: cross
+        with:
+          owner: rust-embedded
+          repo: cross
+          matches: ${{ matrix.platform }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: cross-${{ matrix.platform }}
+          path: ${{ steps.cross.outputs.install_path }}
+    strategy:
+      matrix:
+        platform: [linux-musl]
+
+  windows:
+    runs-on: windows-latest
+    needs: install-cross
+    strategy:
+      matrix:
+        target:
+          # MSVC
+          - i686-pc-windows-msvc
+          - x86_64-pc-windows-msvc
+          # GNU
+          # - i686-pc-windows-gnu
+          # - x86_64-pc-windows-gnu
+    steps:
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - uses: actions/checkout@v2
+      - run: bash ci/set_rust_version.bash stable ${{ matrix.target }}
+      - run: bash ci/build.bash cargo ${{ matrix.target }} RELEASE
+      - run: |
+          cd ./target/${{ matrix.target }}/release/
+          7z a "${{ env.BIN }}.zip" "${{ env.BIN }}.exe"
+          mv "${{ env.BIN }}.zip" $GITHUB_WORKSPACE
+        shell: bash
+        # We're using using a fork of `actions/create-release` that detects
+        # whether a release is already available or not first.
+      - uses: XAMPPRocky/create-release@v1.0.2
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          # Draft should **always** be false. GitHub doesn't provide a way to
+          # get draft releases from its API, so there's no point using it.
+          draft: false
+          prerelease: false
+
+      - uses: actions/upload-release-asset@v1
+        id: upload-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.BIN }}.zip
+          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.zip
+          asset_content_type: application/zip
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target:
+          # macOS
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+          # iOS
+          # - aarch64-apple-ios
+          # - armv7-apple-ios
+          # - armv7s-apple-ios
+          # - i386-apple-ios
+          # - x86_64-apple-ios
+    steps:
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - name: Setup | Checkout
+        uses: actions/checkout@v2
+
+      # Cache files between builds
+      - name: Setup | Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
+
+      - name: Build | Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
+          use-cross: ${{ matrix.os == 'ubuntu-latest' }}
+
+      - run: tar -czvf ${{ env.BIN }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.BIN }}
+      - uses: XAMPPRocky/create-release@v1.0.2
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - uses: actions/upload-release-asset@v1
+        id: upload-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.BIN }}.tar.gz
+          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
+          asset_content_type: application/gzip
+
+  linux:
+    runs-on: ubuntu-latest
+    needs: ["install-cross", "build-web-admin"]
+    strategy:
+      matrix:
+        target:
+          ## WASM, off by default as most rust projects aren't compatible yet.
+          # - wasm32-unknown-emscripten
+          ## Linux
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - arm-unknown-linux-gnueabi
+          - arm-unknown-linux-gnueabihf
+          - armv7-unknown-linux-gnueabihf
+          - i686-unknown-linux-musl
+          - powerpc64le-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          # - i686-unknown-linux-gnu
+          # - mips-unknown-linux-gnu
+          # - mips64-unknown-linux-gnuabi64
+          # - mips64el-unknown-linux-gnuabi64
+          # - mipsel-unknown-linux-gnu
+          # - powerpc-unknown-linux-gnu
+          # - powerpc64-unknown-linux-gnu
+          # - s390x-unknown-linux-gnu
+          # - x86_64-unknown-linux-gnu
+          ## Android
+          # - aarch64-linux-android
+          # - arm-linux-androideabi
+          # - armv7-linux-androideabi
+          # - i686-linux-android
+          # - x86_64-linux-android
+          ## *BSD
+          # The FreeBSD targets can have issues linking so they are disabled
+          # by default.
+          # - i686-unknown-freebsd
+          # - x86_64-unknown-freebsd
+          # - x86_64-unknown-netbsd
+          ## Solaris
+          # - sparcv9-sun-solaris
+          ## Bare Metal
+          # These are no-std embedded targets, so they will only build if your
+          # crate is `no_std` compatible.
+          # - thumbv6m-none-eabi
+          # - thumbv7em-none-eabi
+          # - thumbv7em-none-eabihf
+          # - thumbv7m-none-eabi
+    steps:
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: cross-linux-musl
+          path: /tmp/
+      - run: chmod +x /tmp/cross
+
+      - run: ci/set_rust_version.bash stable ${{ matrix.target }}
+      - run: ci/build.bash /tmp/cross ${{ matrix.target }} RELEASE
+      - run: tar -czvf ${{ env.BIN }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.BIN }}
+      - uses: XAMPPRocky/create-release@v1.0.2
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.BIN }}.tar.gz
+          asset_name: ${{ env.BIN }}-${{steps.tag.outputs.tag}}-${{ matrix.target }}.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -196,7 +196,7 @@ jobs:
           - arm-unknown-linux-gnueabihf
           - armv7-unknown-linux-gnueabihf
           - i686-unknown-linux-musl
-          - powerpc64le-unknown-linux-gnu
+          # - powerpc64le-unknown-linux-gnu
           - x86_64-unknown-linux-musl
           # - i686-unknown-linux-gnu
           # - mips-unknown-linux-gnu

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
   install-cross:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - uses: XAMPPRocky/get-github-release@v1
@@ -26,7 +26,7 @@ jobs:
           repo: cross
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: cross-${{ matrix.platform }}
           path: ${{ steps.cross.outputs.install_path }}
@@ -37,7 +37,7 @@ jobs:
   build-web-admin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
@@ -71,7 +71,7 @@ jobs:
         id: tag
         uses: dawidd6/action-get-tag@v1
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: build-web-admin-artifact-${{steps.tag.outputs.tag}}
@@ -129,7 +129,7 @@ jobs:
         uses: dawidd6/action-get-tag@v1
 
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
@@ -233,13 +233,13 @@ jobs:
         id: tag
         uses: dawidd6/action-get-tag@v1
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: build-web-admin-artifact-${{steps.tag.outputs.tag}}
           path: web-admin/build
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v3
         with:
           name: cross-linux-musl
           path: /tmp/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   # This job downloads and stores `cross` as an artifact, so that it can be
   # re-downloaded across all of the jobs. Currently this copied pasted between
-  # `mean_bean_ci.yml` and `mean_bean_deploy.yml`. Make sure to update both places when making
+  # `ci.yml` and `deploy.yml`. Make sure to update both places when making
   # changes.
   install-cross:
     runs-on: ubuntu-latest
@@ -38,10 +38,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - name: build web
+        uses: actions/setup-node@v3
         with:
           node-version: "16"
       - run: cd web-admin && npm install && CI=false npm run build
+
+      - name: Upload web build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-web-admin-artifact-${{steps.tag.outputs.tag}}
+          path: web-admin/build
 
   windows:
     runs-on: windows-latest
@@ -61,6 +72,11 @@ jobs:
         uses: dawidd6/action-get-tag@v1
 
       - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-web-admin-artifact-${{steps.tag.outputs.tag}}
+          path: web-admin/build
+
       - run: bash ci/set_rust_version.bash stable ${{ matrix.target }}
       - run: bash ci/build.bash cargo ${{ matrix.target }} RELEASE
       - run: |
@@ -114,6 +130,11 @@ jobs:
 
       - name: Setup | Checkout
         uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-web-admin-artifact-${{steps.tag.outputs.tag}}
+          path: web-admin/build
 
       # Cache files between builds
       - name: Setup | Cache Cargo
@@ -213,6 +234,11 @@ jobs:
         uses: dawidd6/action-get-tag@v1
 
       - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-web-admin-artifact-${{steps.tag.outputs.tag}}
+          path: web-admin/build
+
       - uses: actions/download-artifact@v1
         with:
           name: cross-linux-musl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         channel: [stable]
         target:
           # MSVC
-          - i686-pc-windows-msvc
+          # - i686-pc-windows-msvc
           - x86_64-pc-windows-msvc
           # GNU: You typically only need to test Windows GNU if you're
           # specifically targetting it, and it can cause issues with some

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
           node-version: "16"
       - run: cd web-admin && npm install && CI=false npm run build
 
+      - name: Upload web build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-web-admin-artifact-${{ github.sha }}
+          path: web-admin/build
+          retention-days: 1
+
   clippy:
     needs: build-web-admin
     runs-on: ubuntu-latest
@@ -37,6 +44,12 @@ jobs:
           toolchain: stable
           components: clippy
           override: true
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-web-admin-artifact-${{ github.sha }}
+          path: web-admin/build
+
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,6 +88,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 50
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-web-admin-artifact-${{ github.sha }}
+          path: web-admin/build
+
       - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
         shell: bash
       - run: ci/build.bash cargo ${{ matrix.target }}
@@ -120,8 +139,12 @@ jobs:
           profile: minimal
           target: ${{ matrix.target }}
 
-      - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-web-admin-artifact-${{ github.sha }}
+          path: web-admin/build
 
+      - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
       - name: Test
         uses: actions-rs/cargo@v1
         with:
@@ -135,6 +158,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 50
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-web-admin-artifact-${{ github.sha }}
+          path: web-admin/build
 
       - name: Download Cross
         uses: actions/download-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
           - arm-unknown-linux-gnueabihf
           - armv7-unknown-linux-gnueabihf
           - i686-unknown-linux-musl
-          - powerpc64le-unknown-linux-gnu
+          # - powerpc64le-unknown-linux-gnu
           - x86_64-unknown-linux-musl
           # - i686-unknown-linux-gnu
           # - mips-unknown-linux-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,192 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain with rustfmt available
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt
+
+      - run: cargo fmt -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: cargo clippy -- -D warnings
+
+  install-cross:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 50
+      - uses: XAMPPRocky/get-github-release@v1
+        id: cross
+        with:
+          owner: rust-embedded
+          repo: cross
+          matches: ${{ matrix.platform }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: cross-${{ matrix.platform }}
+          path: ${{ steps.cross.outputs.install_path }}
+    strategy:
+      matrix:
+        platform: [linux-musl]
+
+  windows:
+    runs-on: windows-latest
+    # Windows technically doesn't need this, but if we don't block windows on it
+    # some of the windows jobs could fill up the concurrent job queue before
+    # one of the install-cross jobs has started, so this makes sure all
+    # artifacts are downloaded first.
+    needs: install-cross
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
+        shell: bash
+      - run: ci/build.bash cargo ${{ matrix.target }}
+        shell: bash
+      - run: ci/test.bash cargo ${{ matrix.target }}
+        shell: bash
+
+    strategy:
+      fail-fast: true
+      matrix:
+        channel: [stable]
+        target:
+          # MSVC
+          - i686-pc-windows-msvc
+          - x86_64-pc-windows-msvc
+          # GNU: You typically only need to test Windows GNU if you're
+          # specifically targetting it, and it can cause issues with some
+          # dependencies if you're not so it's disabled by self.
+          # - i686-pc-windows-gnu
+          # - x86_64-pc-windows-gnu
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        channel: [stable]
+        target:
+          - x86_64-apple-darwin
+          ### Disable running tests on M1 target, not currently working
+          ###
+          #- aarch64-apple-darwin
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
+
+      - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target ${{ matrix.target }}
+
+  linux:
+    runs-on: ubuntu-latest
+    needs: install-cross
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+
+      - name: Download Cross
+        uses: actions/download-artifact@v1
+        with:
+          name: cross-linux-musl
+          path: /tmp/
+      - run: chmod +x /tmp/cross
+      - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
+      - run: ci/build.bash /tmp/cross ${{ matrix.target }}
+        # These targets have issues with being tested so they are disabled
+        # by default. You can try disabling to see if they work for
+        # your project.
+      - run: ci/test.bash /tmp/cross ${{ matrix.target }}
+        if: |
+          !contains(matrix.target, 'android') &&
+          !contains(matrix.target, 'bsd') &&
+          !contains(matrix.target, 'solaris') &&
+          matrix.target != 'armv5te-unknown-linux-musleabi' &&
+          matrix.target != 'sparc64-unknown-linux-gnu'
+
+    strategy:
+      fail-fast: true
+      matrix:
+        channel: [stable]
+        target:
+          # WASM, off by default as most rust projects aren't compatible yet.
+          # - wasm32-unknown-emscripten
+          # Linux
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - arm-unknown-linux-gnueabi
+          - arm-unknown-linux-gnueabihf
+          - armv7-unknown-linux-gnueabihf
+          - i686-unknown-linux-musl
+          - powerpc64le-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          # - i686-unknown-linux-gnu
+          # - mips-unknown-linux-gnu
+          # - mips64-unknown-linux-gnuabi64
+          # - mips64el-unknown-linux-gnuabi64
+          # - mipsel-unknown-linux-gnu
+          # - powerpc-unknown-linux-gnu
+          # - powerpc64-unknown-linux-gnu
+          # - s390x-unknown-linux-gnu
+          # - x86_64-unknown-linux-gnu
+          ## Android
+          # - aarch64-linux-android
+          # - arm-linux-androideabi
+          # - armv7-linux-androideabi
+          # - i686-linux-android
+          # - x86_64-linux-android
+          ## *BSD
+          # The FreeBSD targets can have issues linking so they are disabled
+          # by default.
+          # - i686-unknown-freebsd
+          # - x86_64-unknown-freebsd
+          # - x86_64-unknown-netbsd
+          ## Solaris
+          # - sparcv9-sun-solaris
+          ## Bare Metal
+          # These are no-std embedded targets, so they will only build if your
+          # crate is `no_std` compatible.
+          # - thumbv6m-none-eabi
+          # - thumbv7em-none-eabi
+          # - thumbv7em-none-eabihf
+          # - thumbv7m-none-eabi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     needs: build-web-admin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -59,7 +59,7 @@ jobs:
   install-cross:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - uses: XAMPPRocky/get-github-release@v1
@@ -69,7 +69,7 @@ jobs:
           repo: cross
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: cross-${{ matrix.platform }}
           path: ${{ steps.cross.outputs.install_path }}
@@ -165,7 +165,7 @@ jobs:
           path: web-admin/build
 
       - name: Download Cross
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: cross-linux-musl
           path: /tmp/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain with rustfmt available
         uses: actions-rs/toolchain@v1
@@ -18,7 +18,17 @@ jobs:
 
       - run: cargo fmt -- --check
 
+  build-web-admin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - run: cd web-admin && npm install && CI=false npm run build
+
   clippy:
+    needs: build-web-admin
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -60,9 +70,9 @@ jobs:
     # some of the windows jobs could fill up the concurrent job queue before
     # one of the install-cross jobs has started, so this makes sure all
     # artifacts are downloaded first.
-    needs: install-cross
+    needs: ["install-cross", "build-web-admin"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
@@ -88,6 +98,7 @@ jobs:
 
   macos:
     runs-on: macos-latest
+    needs: build-web-admin
     strategy:
       fail-fast: true
       matrix:
@@ -99,7 +110,7 @@ jobs:
           #- aarch64-apple-darwin
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1
@@ -119,9 +130,9 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    needs: install-cross
+    needs: ["install-cross", "build-web-admin"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
 

--- a/ci/build.bash
+++ b/ci/build.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Script for building your rust projects.
+set -e
+
+source ci/common.bash
+
+# $1 {path} = Path to cross/cargo executable
+CROSS=$1
+# $1 {string} = <Target Triple> e.g. x86_64-pc-windows-msvc
+TARGET_TRIPLE=$2
+# $3 {boolean} = Are we building for deployment? 
+RELEASE_BUILD=$3
+
+required_arg $CROSS 'CROSS'
+required_arg $TARGET_TRIPLE '<Target Triple>'
+
+if [ -z "$RELEASE_BUILD" ]; then
+    $CROSS build --target $TARGET_TRIPLE
+    $CROSS build --target $TARGET_TRIPLE --all-features
+else
+    $CROSS build --target $TARGET_TRIPLE --all-features --release
+fi
+

--- a/ci/common.bash
+++ b/ci/common.bash
@@ -1,0 +1,6 @@
+required_arg() {
+    if [ -z "$1" ]; then
+        echo "Required argument $2 missing"
+        exit 1
+    fi
+}

--- a/ci/set_rust_version.bash
+++ b/ci/set_rust_version.bash
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+rustup default $1
+rustup target add $2

--- a/ci/test.bash
+++ b/ci/test.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Script for building your rust projects.
+set -e
+
+source ci/common.bash
+
+# $1 {path} = Path to cross/cargo executable
+CROSS=$1
+# $1 {string} = <Target Triple>
+TARGET_TRIPLE=$2
+
+required_arg $CROSS 'CROSS'
+required_arg $TARGET_TRIPLE '<Target Triple>'
+
+$CROSS test --target $TARGET_TRIPLE
+$CROSS test --target $TARGET_TRIPLE --all-features

--- a/src/chain/bitcoind_client.rs
+++ b/src/chain/bitcoind_client.rs
@@ -29,6 +29,9 @@ impl TryInto<FeeResponse> for JsonResponse {
         Ok(FeeResponse {
             errored,
             feerate_sat_per_kw: self.0["feerate"].as_f64().map(|feerate_btc_per_kvbyte| {
+                // Bitcoin Core gives us a feerate in BTC/KvB, which we need to convert to
+                // satoshis/KW. Thus, we first multiply by 10^8 to get satoshis, then divide by 4
+                // to convert virtual-bytes into weight units.
                 (feerate_btc_per_kvbyte * 100_000_000.0 / 4.0).round() as u32
             }),
         })

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -156,13 +156,13 @@ impl
     }
 
     fn persist_graph(&self, network_graph: &NetworkGraph) -> Result<(), std::io::Error> {
-        if !self.external_router && FilesystemPersister::persist_network_graph(self.data_dir.clone(), network_graph)
-                .is_err() {
+        if !self.external_router
+            && FilesystemPersister::persist_network_graph(self.data_dir.clone(), network_graph)
+                .is_err()
+        {
             // Persistence errors here are non-fatal as we can just fetch the routing graph
             // again later, but they may indicate a disk error which could be fatal elsewhere.
-            eprintln!(
-                "Warning: Failed to persist network graph, check your disk and permissions"
-            );
+            eprintln!("Warning: Failed to persist network graph, check your disk and permissions");
         }
         Ok(())
     }

--- a/src/grpc/admin.rs
+++ b/src/grpc/admin.rs
@@ -393,9 +393,8 @@ impl Admin for AdminService {
     ) -> Result<tonic::Response<GetStatusResponse>, tonic::Status> {
         let macaroon_hex_string = raw_macaroon_from_metadata(request.metadata().clone())?;
 
-        let (_macaroon, session) =
-            utils::macaroon_with_session_from_hex_str(&macaroon_hex_string)
-                .map_err(|_e| tonic::Status::unauthenticated("invalid macaroon"))?;
+        let (_macaroon, session) = utils::macaroon_with_session_from_hex_str(&macaroon_hex_string)
+            .map_err(|_e| tonic::Status::unauthenticated("invalid macaroon"))?;
         let pubkey = session.pubkey.clone();
 
         let request = AdminRequest::GetStatus { pubkey };

--- a/src/http/admin.rs
+++ b/src/http/admin.rs
@@ -373,9 +373,7 @@ pub async fn login(
                             .http_only(true)
                             .finish();
                         cookies.add(macaroon_cookie);
-                        let token_cookie = Cookie::build("token", token)
-                            .http_only(true)
-                            .finish();
+                        let token_cookie = Cookie::build("token", token).http_only(true).finish();
                         cookies.add(token_cookie);
                         Ok(Json(json!({
                             "pubkey": node.pubkey,


### PR DESCRIPTION
On push it this will run tests, clippy and check formatting on linux, MacOS and windows.

On a tagged release `(v*)` this will create binaries for windows, linux and macOS and create a GitHub release with binaries attached.

Its not currently passing:

- [CI run](https://github.com/praveenperera/sensei/actions/runs/2180513858)
- [CD run](https://github.com/praveenperera/sensei/actions/runs/2180477182)