### PR TITLE
better handling of hosts display and loopback detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower",
  "tower-http",
  "tower-layer",
@@ -784,7 +784,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -2315,6 +2315,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tonic"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,7 +2350,7 @@ dependencies = [
  "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2373,7 +2386,7 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2398,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ed53e1fd082268841975cb39587fa9fca9a7a30da84f97818ef667c97f2872"
+checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
 dependencies = [
  "bitflags",
  "bytes",
@@ -2415,7 +2428,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ portpicker = "0.1"
 rusqlite = { version = "0.25.3", features = ["uuid", "bundled"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 macaroon = "0.2"
-tower-http = { version = "0.2.0", features = ["fs", "trace", "cors"] }
+tower-http = { version = "0.2.5", features = ["fs", "trace", "cors"] }
 tower-cookies = "0.4"
 dirs = "4.0"
 public-ip = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,10 @@ async fn main() {
             CorsLayer::new()
                 .allow_headers(vec![AUTHORIZATION, ACCEPT, COOKIE, CONTENT_TYPE])
                 .allow_credentials(true)
-                .allow_origin(Origin::list(vec!["http://localhost:3001".parse().unwrap()]))
+                .allow_origin(Origin::list(vec![
+                    "http://localhost:3001".parse().unwrap(),
+                    "http://localhost:5401".parse().unwrap(),
+                ]))
                 .allow_methods(vec![
                     Method::GET,
                     Method::POST,
@@ -182,6 +185,11 @@ async fn main() {
                 ]),
         ),
         None => router,
+    };
+
+    let port = match args.development_mode {
+        Some(_) => String::from("3001"),
+        None => format!("{}", config.api_port),
     };
 
     let http_service = router
@@ -204,7 +212,7 @@ async fn main() {
 
     println!(
         "manage your sensei node at http://localhost:{}/admin/nodes",
-        config.api_port
+        port
     );
 
     if let Err(e) = server.await {

--- a/web-admin/src/nodes/components/NodesList.tsx
+++ b/web-admin/src/nodes/components/NodesList.tsx
@@ -63,7 +63,7 @@ const ActionsColumn = ({ value, node, className }) => {
     {
       label: "open channel",
       icon: <PlusCircleIcon className="w-5" />,
-      path: `/admin/channels/open?connection=${node.pubkey}@127.0.0.1:${node.listenPort}`,
+      path: `/admin/channels/open?connection=${node.pubkey}@${node.listenAddr}:${node.listenPort}`,
     }
   ]
 
@@ -204,7 +204,7 @@ const NodesListCard = () => {
         ...node,
         role: node.role === 0 ? "Sensei" : "Child",
         connectionInfo: `${truncateMiddle(node.pubkey, 10)}@${
-          "127.0.0.1"
+          node.listenAddr
         }:${node.listenPort}`,
         status: node.status === 0 ? "Stopped" : "Running",
         actions: "Action",


### PR DESCRIPTION
Before this we were replacing the node host with 127.0.0.1 in the web admin.  This leaves the host ip as detected by the `public_ip` crate but adds a check when connecting to a peer to see if the peer has the same ip as the host.  If so it connects to the host on 127.0.0.1.  I hope this fixes the umbrel issue if it being hardcoded to 127.0.0.1. 

It might not though since umbrel uses umbrel.local -- though I think that just maps back to localhost anyway.  Worth a test. 

If this doesn't work then we should probably add a configuration option for manually setting the host and use that instead of relying on `public_ip` crate.