### PR TITLE
support port selection within range, 9735 for root node

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,8 @@ pub struct SenseiConfig {
     pub bitcoind_rpc_password: String,
     pub network: Network,
     pub api_port: u16,
+    pub port_range_min: u16,
+    pub port_range_max: u16,
 }
 
 impl Default for SenseiConfig {
@@ -36,6 +38,8 @@ impl Default for SenseiConfig {
             bitcoind_rpc_password: String::from("bitcoin"),
             network: Network::Bitcoin,
             api_port: 5401,
+            port_range_min: 1024,
+            port_range_max: 65535,
         }
     }
 }
@@ -55,6 +59,8 @@ impl SenseiConfig {
                 merge_config.bitcoind_rpc_port = config.bitcoind_rpc_port;
                 merge_config.bitcoind_rpc_username = config.bitcoind_rpc_username;
                 merge_config.bitcoind_rpc_password = config.bitcoind_rpc_password;
+                merge_config.port_range_min = config.port_range_min;
+                merge_config.port_range_max = config.port_range_max;
                 merge_config
             }
             Err(e) => match e.kind() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,12 @@ struct SenseiArgs {
     bitcoind_rpc_password: Option<String>,
     #[clap(long, env = "DEVELOPMENT_MODE")]
     development_mode: Option<bool>,
+    #[clap(long, env = "PORT_RANGE_MIN")]
+    port_range_min: Option<u16>,
+    #[clap(long, env = "PORT_RANGE_MAX")]
+    port_range_max: Option<u16>,
+    #[clap(long, env = "API_PORT")]
+    api_port: Option<u16>,
 }
 
 pub type AdminRequestResponse = (AdminRequest, Sender<AdminResponse>);
@@ -135,6 +141,15 @@ async fn main() {
     }
     if let Some(bitcoind_rpc_password) = args.bitcoind_rpc_password {
         config.bitcoind_rpc_password = bitcoind_rpc_password
+    }
+    if let Some(port_range_min) = args.port_range_min {
+        config.port_range_min = port_range_min;
+    }
+    if let Some(port_range_max) = args.port_range_max {
+        config.port_range_max = port_range_max;
+    }
+    if let Some(api_port) = args.api_port {
+        config.api_port = api_port;
     }
 
     let sqlite_path = format!("{}/{}/admin.db", sensei_dir, config.network);


### PR DESCRIPTION
This adds config and env vars to set a custom range of ports to select within for nodes.

env vars are `PORT_RANGE_MIN` and `PORT_RANGE_MAX`
config opts are `port_range_min` and `port_range_max`
can also set via command line using --port-range-min=1024 --port-range-max=10000

default min is 1024 and default max is 65535

This also sets the root node to use port 9735