### PR TITLE
feat: add verify message endpoint

### DIFF
--- a/proto/sensei.proto
+++ b/proto/sensei.proto
@@ -33,6 +33,7 @@ service Node {
     rpc Info (InfoRequest) returns (InfoResponse);
     rpc ListPeers (ListPeersRequest) returns (ListPeersResponse);
     rpc SignMessage (SignMessageRequest) returns (SignMessageResponse);
+    rpc VerifyMessage (VerifyMessageRequest) returns (VerifyMessageResponse);
 }
 
 message ListNode {
@@ -314,4 +315,13 @@ message SignMessageRequest {
 }
 message SignMessageResponse {
     string signature = 1;
+}
+
+message VerifyMessageRequest {
+    string message = 1;
+    string signature = 2;
+}
+message VerifyMessageResponse {
+    bool valid = 1;
+    string pubkey = 2;
 }

--- a/src/grpc/adaptor.rs
+++ b/src/grpc/adaptor.rs
@@ -21,7 +21,7 @@ use super::sensei::{
     KeysendResponse, ListChannelsRequest, ListChannelsResponse, ListPaymentsRequest,
     ListPaymentsResponse, ListPeersRequest, ListPeersResponse, OpenChannelRequest,
     OpenChannelResponse, PayInvoiceRequest, PayInvoiceResponse, SignMessageRequest,
-    SignMessageResponse,
+    SignMessageResponse, VerifyMessageRequest, VerifyMessageResponse
 };
 
 use crate::database::node::Payment;
@@ -469,6 +469,26 @@ impl TryFrom<NodeResponse> for SignMessageResponse {
     fn try_from(res: NodeResponse) -> Result<Self, Self::Error> {
         match res {
             NodeResponse::SignMessage { signature } => Ok(Self { signature }),
+            _ => Err("impossible".to_string()),
+        }
+    }
+}
+
+impl From<VerifyMessageRequest> for NodeRequest {
+    fn from(req: VerifyMessageRequest) -> Self {
+        NodeRequest::VerifyMessage {
+            message: req.message,
+            signature: req.signature,
+        }
+    }
+}
+
+impl TryFrom<NodeResponse> for VerifyMessageResponse {
+    type Error = String;
+
+    fn try_from(res: NodeResponse) -> Result<Self, Self::Error> {
+        match res {
+            NodeResponse::VerifyMessage { valid, pubkey } => Ok(Self { valid, pubkey }),
             _ => Err("impossible".to_string()),
         }
     }

--- a/src/grpc/adaptor.rs
+++ b/src/grpc/adaptor.rs
@@ -21,7 +21,7 @@ use super::sensei::{
     KeysendResponse, ListChannelsRequest, ListChannelsResponse, ListPaymentsRequest,
     ListPaymentsResponse, ListPeersRequest, ListPeersResponse, OpenChannelRequest,
     OpenChannelResponse, PayInvoiceRequest, PayInvoiceResponse, SignMessageRequest,
-    SignMessageResponse, VerifyMessageRequest, VerifyMessageResponse
+    SignMessageResponse, VerifyMessageRequest, VerifyMessageResponse,
 };
 
 use crate::database::node::Payment;

--- a/src/grpc/node.rs
+++ b/src/grpc/node.rs
@@ -21,7 +21,7 @@ use super::{
         ListPaymentsResponse, ListPeersRequest, ListPeersResponse, OpenChannelRequest,
         OpenChannelResponse, PayInvoiceRequest, PayInvoiceResponse, SignMessageRequest,
         SignMessageResponse, StartNodeRequest, StartNodeResponse, StopNodeRequest,
-        StopNodeResponse,
+        StopNodeResponse, VerifyMessageRequest, VerifyMessageResponse,
     },
     utils::raw_macaroon_from_metadata,
 };

--- a/src/grpc/node.rs
+++ b/src/grpc/node.rs
@@ -280,4 +280,14 @@ impl Node for NodeService {
             .map(Response::new)
             .map_err(|_e| Status::unknown("unknown error"))
     }
+    async fn verify_message(
+        &self,
+        request: tonic::Request<VerifyMessageRequest>,
+    ) -> Result<tonic::Response<VerifyMessageResponse>, tonic::Status> {
+        self.authenticated_request(request.metadata().clone(), request.into_inner().into())
+            .await?
+            .try_into()
+            .map(Response::new)
+            .map_err(|_e| Status::unknown("unknown error"))
+    }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1211,6 +1211,18 @@ impl LightningNode {
         )?)
     }
 
+    pub fn verify_message(&self, message: String, signature: String) -> Result<(bool, String), Error> {
+        let pubkey = self.channel_manager.get_our_node_id();
+
+        let valid = lightning::util::message_signing::verify(
+            message.as_bytes(),
+            &signature,
+            &pubkey,
+        );
+
+        Ok((valid, pubkey.to_string()))
+    }
+
     pub async fn delete_payment(&self, payment_hash: String) -> Result<(), Error> {
         let database = self.database.lock().unwrap();
         database.delete_payment(payment_hash)?;
@@ -1368,6 +1380,13 @@ impl LightningNode {
             NodeRequest::SignMessage { message } => {
                 let signature = self.sign_message(message)?;
                 Ok(NodeResponse::SignMessage { signature })
+            }
+            NodeRequest::VerifyMessage { message, signature } => {
+                let (valid, pubkey) = self.verify_message(message, signature)?;
+                Ok(NodeResponse::VerifyMessage {
+                    valid,
+                    pubkey,
+                })
             }
         }
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,7 +17,7 @@ use crate::disk::{DataPersister, FilesystemLogger};
 use crate::error::Error;
 use crate::event_handler::LightningNodeEventHandler;
 use crate::lib::network_graph::OptionalNetworkGraphMsgHandler;
-use crate::services::node::{Channel, NodeInfo, NodeRequest, NodeRequestError, NodeResponse, Peer};
+use crate::services::node::{Channel, NodeInfo, NodeRequest, NodeRequestError, NodeResponse, Peer, VerifiedMessage};
 use crate::services::{PaginationRequest, PaginationResponse, PaymentsFilter};
 use crate::utils::PagedVec;
 use crate::{database, disk, hex_utils};
@@ -1211,7 +1211,7 @@ impl LightningNode {
         )?)
     }
 
-    pub fn verify_message(&self, message: String, signature: String) -> Result<(bool, String), Error> {
+    pub fn verify_message(&self, message: String, signature: String) -> Result<VerifiedMessage, Error> {
         let pubkey = self.channel_manager.get_our_node_id();
 
         let valid = lightning::util::message_signing::verify(

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,9 +17,7 @@ use crate::disk::{DataPersister, FilesystemLogger};
 use crate::error::Error;
 use crate::event_handler::LightningNodeEventHandler;
 use crate::lib::network_graph::OptionalNetworkGraphMsgHandler;
-use crate::services::node::{
-    Channel, NodeInfo, NodeRequest, NodeRequestError, NodeResponse, Peer, VerifiedMessage,
-};
+use crate::services::node::{Channel, NodeInfo, NodeRequest, NodeRequestError, NodeResponse, Peer};
 use crate::services::{PaginationRequest, PaginationResponse, PaymentsFilter};
 use crate::utils::PagedVec;
 use crate::{database, disk, hex_utils};
@@ -1217,7 +1215,7 @@ impl LightningNode {
         &self,
         message: String,
         signature: String,
-    ) -> Result<VerifiedMessage, Error> {
+    ) -> Result<(bool, String), Error> {
         let pubkey = self.channel_manager.get_our_node_id();
 
         let valid =

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,7 +17,9 @@ use crate::disk::{DataPersister, FilesystemLogger};
 use crate::error::Error;
 use crate::event_handler::LightningNodeEventHandler;
 use crate::lib::network_graph::OptionalNetworkGraphMsgHandler;
-use crate::services::node::{Channel, NodeInfo, NodeRequest, NodeRequestError, NodeResponse, Peer, VerifiedMessage};
+use crate::services::node::{
+    Channel, NodeInfo, NodeRequest, NodeRequestError, NodeResponse, Peer, VerifiedMessage,
+};
 use crate::services::{PaginationRequest, PaginationResponse, PaymentsFilter};
 use crate::utils::PagedVec;
 use crate::{database, disk, hex_utils};
@@ -1211,14 +1213,15 @@ impl LightningNode {
         )?)
     }
 
-    pub fn verify_message(&self, message: String, signature: String) -> Result<VerifiedMessage, Error> {
+    pub fn verify_message(
+        &self,
+        message: String,
+        signature: String,
+    ) -> Result<VerifiedMessage, Error> {
         let pubkey = self.channel_manager.get_our_node_id();
 
-        let valid = lightning::util::message_signing::verify(
-            message.as_bytes(),
-            &signature,
-            &pubkey,
-        );
+        let valid =
+            lightning::util::message_signing::verify(message.as_bytes(), &signature, &pubkey);
 
         Ok((valid, pubkey.to_string()))
     }
@@ -1383,10 +1386,7 @@ impl LightningNode {
             }
             NodeRequest::VerifyMessage { message, signature } => {
                 let (valid, pubkey) = self.verify_message(message, signature)?;
-                Ok(NodeResponse::VerifyMessage {
-                    valid,
-                    pubkey,
-                })
+                Ok(NodeResponse::VerifyMessage { valid, pubkey })
             }
         }
     }

--- a/src/services/node.rs
+++ b/src/services/node.rs
@@ -37,7 +37,7 @@ pub struct NodeInfo {
 }
 
 #[derive(Serialize)]
-pub struct VerifyResponse {
+pub struct VerifiedMessage {
     pub valid: bool,
     pub pubkey: String,
 }

--- a/src/services/node.rs
+++ b/src/services/node.rs
@@ -36,12 +36,6 @@ pub struct NodeInfo {
     pub local_balance_msat: u64,
 }
 
-#[derive(Serialize)]
-pub struct VerifiedMessage {
-    pub valid: bool,
-    pub pubkey: String,
-}
-
 // #[derive(Serialize)]
 // pub struct Payment {
 //     pub hash: String,

--- a/src/services/node.rs
+++ b/src/services/node.rs
@@ -36,6 +36,12 @@ pub struct NodeInfo {
     pub local_balance_msat: u64,
 }
 
+#[derive(Serialize)]
+pub struct VerifyResponse {
+    pub valid: bool,
+    pub pubkey: String,
+}
+
 // #[derive(Serialize)]
 // pub struct Payment {
 //     pub hash: String,
@@ -167,6 +173,10 @@ pub enum NodeRequest {
     SignMessage {
         message: String,
     },
+    VerifyMessage {
+        message: String,
+        signature: String,
+    },
 }
 
 #[derive(Serialize)]
@@ -210,6 +220,10 @@ pub enum NodeResponse {
     },
     SignMessage {
         signature: String,
+    },
+    VerifyMessage {
+        valid: bool,
+        pubkey: String,
     },
     Error(NodeRequestError),
 }


### PR DESCRIPTION
This PR adds the `POST /v1/node/verify/message` endpoint, used to verify a signed message. First rust PR, so let me know if it needs improvements.

Tested and working (on`main`).