### PR TITLE
Add --dev argument to the CLI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -200,7 +200,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .get_matches();
 
     let endpoint = if matches.is_present("dev") {
-         "http://0.0.0.0:5401"
+        "http://0.0.0.0:5401"
     } else {
         "http://0.0.0.0:3000"
     };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .help("Sets the node to issue commands to")
                 .takes_value(true),
         )
+        .arg(
+            Arg::new("dev")
+                .long("dev")
+                .value_name("DEVELOPMENT_MODE")
+                .help("Sets the development mode endpoint")
+                .takes_value(false),
+        )
         .subcommand(
             App::new("init")
                 .about("initialize your Sensei node")
@@ -192,10 +199,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .subcommand(App::new("nodeinfo").about("see information about your node"))
         .get_matches();
 
+    let endpoint = if matches.is_present("dev") {
+         "http://0.0.0.0:5401"
+    } else {
+        "http://0.0.0.0:3000"
+    };
+
     let (command, command_args) = matches.subcommand().unwrap();
 
     if command == "init" {
-        let channel = Channel::from_static("http://0.0.0.0:3000")
+        let channel = Channel::from_static(endpoint)
             .connect()
             .await?;
         let mut admin_client = AdminClient::new(channel);
@@ -227,7 +240,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _bytes = macaroon_file.read_to_end(&mut macaroon_raw)?;
         let macaroon_hex_str = hex_utils::hex_str(&macaroon_raw);
 
-        let channel = Channel::from_static("http://0.0.0.0:3000")
+        let channel = Channel::from_static(endpoint)
             .connect()
             .await?;
         let macaroon = MetadataValue::from_str(&macaroon_hex_str)?;

--- a/src/http/admin.rs
+++ b/src/http/admin.rs
@@ -212,6 +212,7 @@ pub async fn authenticate_request(
 
 pub fn add_routes(router: Router) -> Router {
     router
+        .route("/health", post(health_check))
         .route("/v1/init", post(init_sensei))
         .route("/v1/nodes", get(list_nodes))
         .route("/v1/nodes", post(create_node))
@@ -395,6 +396,10 @@ pub async fn logout(cookies: Cookies) -> Result<Json<Value>, StatusCode> {
     cookies.remove(Cookie::new("macaroon", ""));
     cookies.remove(Cookie::new("token", ""));
     Ok(Json::default())
+}
+
+pub async fn health_check() -> Result<String, StatusCode> {
+    Ok("Up!".to_string())
 }
 
 pub async fn init_sensei(


### PR DESCRIPTION
When running senseid in dev mode, the admin endpoint is port 5401.  The CLI was hardcoded to port 3000.

This adds the ability to pass a --dev flag to the CLI and set the endpoint correctly.

It would probably be better to improve this logic even more, and possibly improve documentation.  It may also be worth porting this cli to use clap rather than this command line parsing strategy.

The command can be invoked as follows:

`cargo run --bin senseicli -- --dev init <username> <alias>`