### PR TITLE
feat: add Sensei version

### DIFF
--- a/proto/sensei.proto
+++ b/proto/sensei.proto
@@ -146,13 +146,14 @@ message StartAdminResponse {
 
 message GetStatusRequest {}
 message GetStatusResponse {
-    optional string alias = 1;
-    optional string pubkey = 2;
-    optional string username = 3;
-    optional uint32 role = 4;
-    bool created = 5;
-    bool running = 6;
-    bool authenticated = 7;
+    string version = 1;
+    optional string alias = 2;
+    optional string pubkey = 3;
+    optional string username = 4;
+    optional uint32 role = 5;
+    bool created = 6;
+    bool running = 7;
+    bool authenticated = 8;
 }
 
 message StartNodeRequest {
@@ -289,10 +290,11 @@ message CloseChannelRequest {
 message CloseChannelResponse {}
 
 message Info {
-    string node_pubkey = 1;
-    uint32 num_channels = 2;
-    uint32 num_usable_channels = 3;
-    uint32 num_peers = 4;
+    string version = 1;
+    string node_pubkey = 2;
+    uint32 num_channels = 3;
+    uint32 num_usable_channels = 4;
+    uint32 num_peers = 5;
 }
 
 message InfoRequest {}

--- a/src/grpc/adaptor.rs
+++ b/src/grpc/adaptor.rs
@@ -107,6 +107,7 @@ impl From<Payment> for PaymentMessage {
 impl From<NodeInfo> for InfoMessage {
     fn from(info: NodeInfo) -> Self {
         Self {
+            version: info.version,
             node_pubkey: info.node_pubkey,
             num_channels: info.num_channels,
             num_usable_channels: info.num_usable_channels,

--- a/src/grpc/admin.rs
+++ b/src/grpc/admin.rs
@@ -191,6 +191,7 @@ impl TryFrom<AdminResponse> for GetStatusResponse {
     fn try_from(res: AdminResponse) -> Result<Self, Self::Error> {
         match res {
             AdminResponse::GetStatus {
+                version,
                 alias,
                 running,
                 created,
@@ -199,6 +200,7 @@ impl TryFrom<AdminResponse> for GetStatusResponse {
                 username,
                 role,
             } => Ok(Self {
+                version,
                 alias,
                 running,
                 created,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod lib;
 mod node;
 mod services;
 mod utils;
+mod version;
 
 use crate::chain::bitcoind_client::BitcoindClient;
 use crate::database::admin::AdminDatabase;

--- a/src/node.rs
+++ b/src/node.rs
@@ -21,7 +21,7 @@ use crate::lib::persist::{AnyKVStore, DatabaseStore, FileStore, SenseiPersister}
 use crate::services::node::{Channel, NodeInfo, NodeRequest, NodeRequestError, NodeResponse, Peer};
 use crate::services::{PaginationRequest, PaginationResponse, PaymentsFilter};
 use crate::utils::PagedVec;
-use crate::{database, hex_utils};
+use crate::{database, hex_utils, version};
 use bdk::database::SqliteDatabase;
 use bdk::keys::ExtendedKey;
 use bdk::wallet::AddressIndex;
@@ -1166,6 +1166,7 @@ impl LightningNode {
         let local_balance_msat = chans.iter().map(|c| c.balance_msat).sum::<u64>();
 
         Ok(NodeInfo {
+            version: version::get_version(),
             node_pubkey: self.channel_manager.get_our_node_id().to_string(),
             num_channels: chans.len() as u32,
             num_usable_channels: chans.iter().filter(|c| c.is_usable).count() as u32,

--- a/src/services/admin.rs
+++ b/src/services/admin.rs
@@ -19,7 +19,7 @@ use crate::{
     config::{LightningNodeConfig, SenseiConfig},
     hex_utils,
     node::LightningNode,
-    NodeDirectory, NodeHandle,
+    version, NodeDirectory, NodeHandle,
 };
 
 use rand::Rng;
@@ -77,6 +77,7 @@ pub enum AdminRequest {
 #[serde(untagged)]
 pub enum AdminResponse {
     GetStatus {
+        version: String,
         alias: Option<String>,
         created: bool,
         running: bool,
@@ -195,6 +196,7 @@ impl AdminService {
                                 let node_running = directory.contains_key(&pubkey);
 
                                 Ok(AdminResponse::GetStatus {
+                                    version: version::get_version(),
                                     alias: Some(pubkey_node.alias),
                                     created: true,
                                     running: node_running,
@@ -205,6 +207,7 @@ impl AdminService {
                                 })
                             }
                             None => Ok(AdminResponse::GetStatus {
+                                version: version::get_version(),
                                 alias: None,
                                 created: true,
                                 running: false,
@@ -216,6 +219,7 @@ impl AdminService {
                         }
                     }
                     None => Ok(AdminResponse::GetStatus {
+                        version: version::get_version(),
                         alias: None,
                         pubkey: None,
                         created: false,

--- a/src/services/node.rs
+++ b/src/services/node.rs
@@ -29,6 +29,7 @@ pub struct Peer {
 
 #[derive(Serialize)]
 pub struct NodeInfo {
+    pub version: String,
     pub node_pubkey: String,
     pub num_channels: u32,
     pub num_usable_channels: u32,

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,23 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+const APP_MAJOR: u8 = 0;
+const APP_MINOR: u8 = 2;
+const APP_PATCH: u8 = 1;
+const APP_PRE_RELEASE: &str = "";
+
+pub fn get_version() -> String {
+    let mut version = format!("{}.{}.{}", APP_MAJOR, APP_MINOR, APP_PATCH);
+
+    if !APP_PRE_RELEASE.is_empty() {
+        version = format!("{}-{}", version, APP_PRE_RELEASE);
+    }
+
+    version
+}


### PR DESCRIPTION
This PR allows us to retrieve the hardcoded Sensei current version using ``version::get_version()``.

`GET /v1/status` and `GET /v1/node/info` responses now include `version` as well.

Tested and working on `main`.

Step towards #43.