### PR TITLE
Fix admin default route redirection

### DIFF
--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -62,9 +62,8 @@ function App() {
           <Route path="/admin/nodes/new" element={<NewNodePage />} />
           <Route path="/admin/tokens" element={<TokensPage />} />
           <Route path="/admin/tokens/new" element={<NewTokenPage />} />
+          <Route index element={<Navigate to="/admin/chain" replace />} />
         </Route>
-
-        <Route path="/*" element={<Navigate to="/admin/chain" replace />} />
       </Routes>
       <Modal />
       <ErrorModal />


### PR DESCRIPTION
I noticed that going to `/admin` in the UI just shows the admin nav. The default redirection to `/admin/chain` appeared to be in there but wasn't working. This fixes that redirection so that it correctly redirects to `/admin/chain` when someone just goes to `/admin`.