### PR TITLE
Add connection node info to response when creating a child node

### DIFF
--- a/proto/sensei.proto
+++ b/proto/sensei.proto
@@ -115,6 +115,9 @@ message CreateNodeRequest {
 message CreateNodeResponse {
     string pubkey = 1;
     string macaroon = 2;
+    string listen_addr = 3;
+    int32 listen_port = 4;
+    string id = 5;
 }
 
 message DeleteNodeRequest {

--- a/src/grpc/admin.rs
+++ b/src/grpc/admin.rs
@@ -120,7 +120,19 @@ impl TryFrom<AdminResponse> for CreateNodeResponse {
 
     fn try_from(res: AdminResponse) -> Result<Self, Self::Error> {
         match res {
-            AdminResponse::CreateNode { pubkey, macaroon } => Ok(Self { pubkey, macaroon }),
+            AdminResponse::CreateNode {
+                pubkey,
+                macaroon,
+                listen_addr,
+                listen_port,
+                id,
+            } => Ok(Self {
+                pubkey,
+                macaroon,
+                listen_addr,
+                listen_port,
+                id,
+            }),
             _ => Err("impossible".to_string()),
         }
     }

--- a/src/services/admin.rs
+++ b/src/services/admin.rs
@@ -97,6 +97,9 @@ pub enum AdminResponse {
     CreateNode {
         pubkey: String,
         macaroon: String,
+        listen_addr: String,
+        listen_port: i32,
+        id: String,
     },
     ListNodes {
         nodes: Vec<node::Model>,
@@ -316,6 +319,9 @@ impl AdminService {
                 Ok(AdminResponse::CreateNode {
                     pubkey: node.pubkey,
                     macaroon: hex_utils::hex_str(macaroon.as_slice()),
+                    listen_addr: node.listen_addr,
+                    listen_port: node.listen_port,
+                    id: node.id,
                 })
             }
             AdminRequest::ListNodes { pagination } => {


### PR DESCRIPTION
Adds connection info in proto response when creating a child node. Closes #70 