### PR TITLE
improvements to integration test

### DIFF
--- a/proto/sensei.proto
+++ b/proto/sensei.proto
@@ -194,7 +194,9 @@ message OpenChannelRequest {
     uint64 amt_satoshis = 2;
     bool public = 3;
 }
-message OpenChannelResponse {}
+message OpenChannelResponse {
+    string temp_channel_id = 1;
+}
 
 message PayInvoiceRequest {
     string invoice = 1;

--- a/senseicore/src/chain/bitcoind_client.rs
+++ b/senseicore/src/chain/bitcoind_client.rs
@@ -119,8 +119,8 @@ impl BitcoindClient {
             })?;
         let mut fees: HashMap<Target, AtomicU32> = HashMap::new();
         fees.insert(Target::Background, AtomicU32::new(MIN_FEERATE));
-        fees.insert(Target::Normal, AtomicU32::new(2000));
-        fees.insert(Target::HighPriority, AtomicU32::new(5000));
+        fees.insert(Target::Normal, AtomicU32::new(2000)); // 8 sats per byte
+        fees.insert(Target::HighPriority, AtomicU32::new(5000)); // 20 sats per byte
         let client = Self {
             bitcoind_rpc_client: Arc::new(Mutex::new(bitcoind_rpc_client)),
             fees: Arc::new(fees),

--- a/senseicore/src/node.rs
+++ b/senseicore/src/node.rs
@@ -835,6 +835,7 @@ impl LightningNode {
             tokio_handle: Handle::current(),
             chain_manager: chain_manager.clone(),
             event_sender: event_sender.clone(),
+            broadcaster: broadcaster.clone(),
         });
 
         let invoice_payer = Arc::new(InvoicePayer::new(
@@ -1473,13 +1474,14 @@ impl LightningNode {
                     Ok(temp_channel_id) => {
                         let _ = self.persister.persist_channel_peer(&node_connection_string);
                         Ok(NodeResponse::OpenChannel {
-                            temp_channel_id: hex_utils::hex_str(&temp_channel_id)
+                            temp_channel_id: hex_utils::hex_str(&temp_channel_id),
                         })
-                    },
-                    Err(e) => {
-                        Ok(NodeResponse::Error(NodeRequestError::Sensei(format!("Failed to open channel: {:?}", e))))
                     }
-                }    
+                    Err(e) => Ok(NodeResponse::Error(NodeRequestError::Sensei(format!(
+                        "Failed to open channel: {:?}",
+                        e
+                    )))),
+                }
             }
             NodeRequest::SendPayment { invoice } => {
                 let invoice = self.get_invoice_from_str(&invoice)?;

--- a/senseicore/src/node.rs
+++ b/senseicore/src/node.rs
@@ -1469,11 +1469,17 @@ impl LightningNode {
 
                 let res = self.open_channel(pubkey, amt_satoshis, 0, 0, public);
 
-                if res.is_ok() {
-                    let _ = self.persister.persist_channel_peer(&node_connection_string);
-                }
-
-                Ok(NodeResponse::OpenChannel {})
+                match res {
+                    Ok(temp_channel_id) => {
+                        let _ = self.persister.persist_channel_peer(&node_connection_string);
+                        Ok(NodeResponse::OpenChannel {
+                            temp_channel_id: hex_utils::hex_str(&temp_channel_id)
+                        })
+                    },
+                    Err(e) => {
+                        Ok(NodeResponse::Error(NodeRequestError::Sensei(format!("Failed to open channel: {:?}", e))))
+                    }
+                }    
             }
             NodeRequest::SendPayment { invoice } => {
                 let invoice = self.get_invoice_from_str(&invoice)?;

--- a/senseicore/src/services/admin.rs
+++ b/senseicore/src/services/admin.rs
@@ -554,4 +554,19 @@ impl AdminService {
 
         Ok(())
     }
+
+    pub async fn stop(&self) -> Result<(), crate::error::Error> {
+        let pubkeys = {
+            let node_directory = self.node_directory.lock().await;
+            node_directory.keys().cloned().collect::<Vec<String>>()
+        };
+
+        for pubkey in pubkeys.into_iter() {
+            self.stop_node(pubkey).await.unwrap();
+        }
+
+        self.chain_manager.stop().await;
+
+        Ok(())
+    }
 }

--- a/senseicore/src/services/node.rs
+++ b/senseicore/src/services/node.rs
@@ -187,7 +187,9 @@ pub enum NodeResponse {
     GetBalance {
         balance_satoshis: u64,
     },
-    OpenChannel {},
+    OpenChannel {
+        temp_channel_id: String
+    },
     SendPayment {},
     DecodeInvoice {
         invoice: LocalInvoice,

--- a/senseicore/src/services/node.rs
+++ b/senseicore/src/services/node.rs
@@ -188,7 +188,7 @@ pub enum NodeResponse {
         balance_satoshis: u64,
     },
     OpenChannel {
-        temp_channel_id: String
+        temp_channel_id: String,
     },
     SendPayment {},
     DecodeInvoice {

--- a/senseicore/tests/smoke_test.rs
+++ b/senseicore/tests/smoke_test.rs
@@ -424,6 +424,8 @@ mod test {
         };
 
         assert!(wait_until(has_payments, 60000, 500).await);
+
+
     }
 
     #[test]

--- a/src/grpc/adaptor.rs
+++ b/src/grpc/adaptor.rs
@@ -204,7 +204,7 @@ impl TryFrom<NodeResponse> for OpenChannelResponse {
 
     fn try_from(res: NodeResponse) -> Result<Self, Self::Error> {
         match res {
-            NodeResponse::OpenChannel {} => Ok(Self {}),
+            NodeResponse::OpenChannel { temp_channel_id } => Ok(Self { temp_channel_id }),
             _ => Err("impossible".to_string()),
         }
     }


### PR DESCRIPTION
Updates the new integration test to be a bit more thorough and more reliable.

It now exercises almost all of the core sensei and lightning functionalities.

- Initializes Sensei instance and root node
- Creates two extra nodes
- Funds nodes with some btc
- Opens channels between the nodes
- Routes 25 2-hop payments from first to last node
- Cooperatively closes the first channel
- Force closes the next channel
- Ensures everyones balances are what we expect

