### PR TITLE
batch channel opens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target
 /.sensei-tests
-./senseicore/.sensei-tests
+/senseicore/.sensei-tests
 .DS_Store
 *_pb2.py
 *_pb2_grpc.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,12 +1053,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,19 +2225,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2288,21 +2269,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -2326,15 +2292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2765,12 +2722,13 @@ dependencies = [
  "portpicker",
  "prost",
  "public-ip",
- "rand 0.4.6",
+ "rand 0.8.5",
  "rusqlite",
  "rust-embed",
  "senseicore",
  "serde",
  "serde_json",
+ "serial_test",
  "tindercrypt",
  "tokio",
  "tonic",
@@ -2815,10 +2773,11 @@ dependencies = [
  "pin-project",
  "portpicker",
  "public-ip",
- "rand 0.4.6",
+ "rand 0.8.5",
  "rust-embed",
  "serde",
  "serde_json",
+ "serial_test",
  "tindercrypt",
  "tokio",
  "tower",
@@ -2867,6 +2826,30 @@ dependencies = [
  "itoa 1.0.2",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881bccd7d60fb32dfa3d7b3136385312f8ad75e2674aab2852867a09790cae8"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ bitcoin-bech32 = "0.12"
 bech32 = "0.8"
 futures = "0.3"
 chrono = "0.4"
-rand = "0.4"
+rand = "0.8.4"
 axum = { version = "0.4.2", features = ["headers"] }
 http = "0.2"
 tower = { version = "0.4", features = ["full"] }
@@ -64,6 +64,7 @@ tonic-build = "0.6"
 
 [dev-dependencies]
 bitcoind = { version = "0.26", features = [ "22_0" ] }
+serial_test = "0.6.0"
 
 [[test]]
 name = "senseicore"

--- a/proto/sensei.proto
+++ b/proto/sensei.proto
@@ -20,7 +20,7 @@ service Node {
     rpc StopNode (StopNodeRequest) returns (StopNodeResponse);
     rpc GetUnusedAddress (GetUnusedAddressRequest) returns (GetUnusedAddressResponse);
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse);
-    rpc OpenChannel (OpenChannelRequest) returns (OpenChannelResponse);
+    rpc OpenChannels (OpenChannelsRequest) returns (OpenChannelsResponse);
     rpc PayInvoice (PayInvoiceRequest) returns (PayInvoiceResponse);
     rpc DecodeInvoice (DecodeInvoiceRequest) returns (DecodeInvoiceResponse);
     rpc Keysend (KeysendRequest) returns (KeysendResponse);
@@ -189,13 +189,24 @@ message GetBalanceResponse {
     uint64 balance_satoshis = 1;
 }
 
-message OpenChannelRequest {
+message OpenChannelInfo {
     string node_connection_string = 1;
     uint64 amt_satoshis = 2;
     bool public = 3;
 }
-message OpenChannelResponse {
-    string temp_channel_id = 1;
+
+message OpenChannelResult {
+    bool error = 1;
+    optional string error_message = 2;
+    optional string temp_channel_id = 3;
+}
+
+message OpenChannelsRequest {
+    repeated OpenChannelInfo channels = 1;
+}
+message OpenChannelsResponse {
+    repeated OpenChannelInfo channels = 1;
+    repeated OpenChannelResult results = 2;
 }
 
 message PayInvoiceRequest {

--- a/senseicore/Cargo.toml
+++ b/senseicore/Cargo.toml
@@ -21,7 +21,7 @@ bitcoin-bech32 = "0.12"
 bech32 = "0.8"
 futures = "0.3"
 chrono = "0.4"
-rand = "0.4"
+rand = "0.8.4"
 axum = { version = "0.4.2", features = ["headers"] }
 http = "0.2"
 tower = { version = "0.4", features = ["full"] }
@@ -49,3 +49,4 @@ migration = { path = "../migration" }
 
 [dev-dependencies]
 bitcoind = { version = "0.26", features = [ "22_0" ] }
+serial_test = "0.6.0"

--- a/senseicore/src/chain/broadcaster.rs
+++ b/senseicore/src/chain/broadcaster.rs
@@ -1,21 +1,45 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use crate::events::SenseiEvent;
 
 use super::database::WalletDatabase;
-use bitcoin::Transaction;
+use bitcoin::{Transaction, Txid};
 use lightning::chain::chaininterface::BroadcasterInterface;
 use tokio::sync::broadcast;
 
 pub struct SenseiBroadcaster {
+    pub debounce: Mutex<HashMap<Txid, usize>>,
     pub node_id: String,
     pub broadcaster: Arc<dyn BroadcasterInterface + Send + Sync>,
     pub wallet_database: Arc<Mutex<WalletDatabase>>,
     pub event_sender: broadcast::Sender<SenseiEvent>,
 }
 
-impl BroadcasterInterface for SenseiBroadcaster {
-    fn broadcast_transaction(&self, tx: &Transaction) {
+impl SenseiBroadcaster {
+    pub fn new(
+        node_id: String,
+        broadcaster: Arc<dyn BroadcasterInterface + Send + Sync>,
+        wallet_database: Arc<Mutex<WalletDatabase>>,
+        event_sender: broadcast::Sender<SenseiEvent>,
+    ) -> Self {
+        Self {
+            node_id,
+            broadcaster,
+            wallet_database,
+            event_sender,
+            debounce: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn set_debounce(&self, txid: Txid, count: usize) {
+        let mut debounce = self.debounce.lock().unwrap();
+        debounce.insert(txid, count);
+    }
+
+    pub fn broadcast(&self, tx: &Transaction) {
         self.broadcaster.broadcast_transaction(tx);
 
         // TODO: there's a bug here if the broadcast fails
@@ -29,5 +53,25 @@ impl BroadcasterInterface for SenseiBroadcaster {
                 txid: tx.txid(),
             })
             .unwrap_or_default();
+    }
+}
+
+impl BroadcasterInterface for SenseiBroadcaster {
+    fn broadcast_transaction(&self, tx: &Transaction) {
+        let txid = tx.txid();
+
+        let mut debounce = self.debounce.lock().unwrap();
+
+        let can_broadcast = match debounce.get_mut(&txid) {
+            Some(count) => {
+                *count -= 1;
+                *count == 0
+            }
+            None => true,
+        };
+
+        if can_broadcast {
+            self.broadcast(tx);
+        }
     }
 }

--- a/senseicore/src/channels.rs
+++ b/senseicore/src/channels.rs
@@ -139,8 +139,8 @@ impl ChannelOpener {
                         } = event
                         {
                             if *user_channel_id == request.custom_id {
-                              channel_counterparty_node_id = Some(*counterparty_node_id);
-                              return true;
+                                channel_counterparty_node_id = Some(*counterparty_node_id);
+                                return true;
                             }
                         }
                         false
@@ -149,10 +149,10 @@ impl ChannelOpener {
                     if event.is_none() {
                         (request, Err(Error::FundingGenerationNeverHappened), None)
                     } else {
-                      (request, result, channel_counterparty_node_id)
+                        (request, result, channel_counterparty_node_id)
                     }
                 } else {
-                  (request, result, None)
+                    (request, result, None)
                 }
             })
             .collect::<Vec<_>>();
@@ -192,7 +192,7 @@ impl ChannelOpener {
 
         let channels_to_open = requests_with_results
             .iter()
-            .filter(|(_request, result, counterparty_node_id)| result.is_ok())
+            .filter(|(_request, result, _counterparty_node_id)| result.is_ok())
             .count();
 
         self.broadcaster
@@ -203,10 +203,11 @@ impl ChannelOpener {
             .map(|(request, result, counterparty_node_id)| {
                 if let Ok(tcid) = result {
                     let counterparty_node_id = counterparty_node_id.unwrap();
-                    match self
-                        .channel_manager
-                        .funding_transaction_generated(&tcid, &counterparty_node_id, funding_tx.clone())
-                    {
+                    match self.channel_manager.funding_transaction_generated(
+                        &tcid,
+                        &counterparty_node_id,
+                        funding_tx.clone(),
+                    ) {
                         Ok(()) => (request, result),
                         Err(e) => (request, Err(Error::LdkApi(e))),
                     }

--- a/senseicore/src/channels.rs
+++ b/senseicore/src/channels.rs
@@ -1,0 +1,255 @@
+use crate::chain::broadcaster::SenseiBroadcaster;
+use crate::chain::manager::SenseiChainManager;
+use crate::error::Error;
+use crate::{chain::database::WalletDatabase, events::SenseiEvent, node::ChannelManager};
+use bdk::{FeeRate, SignOptions};
+use bitcoin::secp256k1::PublicKey;
+use lightning::chain::chaininterface::ConfirmationTarget;
+use lightning::util::config::{ChannelConfig, ChannelHandshakeLimits, UserConfig};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+pub struct EventFilter<F>
+where
+    F: Fn(SenseiEvent) -> bool,
+{
+    pub f: F,
+}
+
+pub struct ChannelOpenRequest {
+    pub node_connection_string: String,
+    pub peer_pubkey: PublicKey,
+    pub channel_amt_sat: u64,
+    pub push_amt_msat: u64,
+    pub custom_id: u64,
+    pub announced_channel: bool,
+}
+
+pub struct ChannelOpener {
+    node_id: String,
+    channel_manager: Arc<ChannelManager>,
+    wallet: Arc<Mutex<bdk::Wallet<WalletDatabase>>>,
+    chain_manager: Arc<SenseiChainManager>,
+    event_receiver: broadcast::Receiver<SenseiEvent>,
+    broadcaster: Arc<SenseiBroadcaster>,
+}
+
+impl ChannelOpener {
+    pub fn new(
+        node_id: String,
+        channel_manager: Arc<ChannelManager>,
+        chain_manager: Arc<SenseiChainManager>,
+        wallet: Arc<Mutex<bdk::Wallet<WalletDatabase>>>,
+        event_receiver: broadcast::Receiver<SenseiEvent>,
+        broadcaster: Arc<SenseiBroadcaster>,
+    ) -> Self {
+        Self {
+            node_id,
+            channel_manager,
+            chain_manager,
+            wallet,
+            event_receiver,
+            broadcaster,
+        }
+    }
+
+    async fn wait_for_events<F: Fn(SenseiEvent) -> bool>(
+        &mut self,
+        mut filters: Vec<EventFilter<F>>,
+        timeout_ms: u64,
+        interval_ms: u64,
+    ) -> Vec<SenseiEvent> {
+        let mut events = vec![];
+        let mut current_ms = 0;
+        while current_ms < timeout_ms {
+            while let Ok(event) = self.event_receiver.try_recv() {
+                let filter_index = filters
+                    .iter()
+                    .enumerate()
+                    .find(|(_index, filter)| (filter.f)(event.clone()))
+                    .map(|(index, _filter)| index);
+
+                if let Some(index) = filter_index {
+                    events.push(event);
+                    filters.swap_remove(index);
+                }
+
+                if filters.is_empty() {
+                    return events;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(interval_ms)).await;
+            current_ms += interval_ms;
+        }
+        events
+    }
+
+    pub async fn open_batch(
+        &mut self,
+        requests: Vec<ChannelOpenRequest>,
+    ) -> Vec<(ChannelOpenRequest, Result<[u8; 32], Error>)> {
+        let mut requests_with_results = requests
+            .into_iter()
+            .map(|request| {
+                let result = self.initiate_channel_open(&request);
+
+                (request, result)
+            })
+            .collect::<Vec<_>>();
+
+        let filters = requests_with_results
+            .iter()
+            .filter(|(_request, result)| result.is_ok())
+            .map(|(request, _result)| {
+                let filter_node_id = self.node_id.clone();
+                let request_user_channel_id = request.custom_id;
+                let filter = move |event| {
+                    if let SenseiEvent::FundingGenerationReady {
+                        node_id,
+                        user_channel_id,
+                        ..
+                    } = event
+                    {
+                        if *node_id == filter_node_id && user_channel_id == request_user_channel_id
+                        {
+                            return true;
+                        }
+                    }
+                    false
+                };
+                EventFilter { f: filter }
+            })
+            .collect::<Vec<EventFilter<_>>>();
+
+        // TODO: is this appropriate timeout? maybe should accept as param
+        let events = self.wait_for_events(filters, 15000, 500).await;
+
+        // set error state for requests we didn't get an event for
+        let requests_with_results = requests_with_results
+            .drain(..)
+            .map(|(request, result)| {
+                if result.is_ok() {
+                    let mut channel_counterparty_node_id = None;
+                    let event = events.iter().find(|event| {
+                        if let SenseiEvent::FundingGenerationReady {
+                            user_channel_id,
+                            counterparty_node_id,
+                            ..
+                        } = event
+                        {
+                            if *user_channel_id == request.custom_id {
+                              channel_counterparty_node_id = Some(*counterparty_node_id);
+                              return true;
+                            }
+                        }
+                        false
+                    });
+
+                    if event.is_none() {
+                        (request, Err(Error::FundingGenerationNeverHappened), None)
+                    } else {
+                      (request, result, channel_counterparty_node_id)
+                    }
+                } else {
+                  (request, result, None)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // build a tx with these events and requests
+        let wallet = self.wallet.lock().unwrap();
+
+        let mut tx_builder = wallet.build_tx();
+        let fee_sats_per_1000_wu = self
+            .chain_manager
+            .fee_estimator
+            .get_est_sat_per_1000_weight(ConfirmationTarget::Normal);
+
+        // TODO: is this the correct conversion??
+        let sat_per_vb = match fee_sats_per_1000_wu {
+            253 => 1.0,
+            _ => fee_sats_per_1000_wu as f32 / 250.0,
+        } as f32;
+
+        let fee_rate = FeeRate::from_sat_per_vb(sat_per_vb);
+
+        events.iter().for_each(|event| {
+            if let SenseiEvent::FundingGenerationReady {
+                channel_value_satoshis,
+                output_script,
+                ..
+            } = event
+            {
+                tx_builder.add_recipient(output_script.clone(), *channel_value_satoshis);
+            }
+        });
+
+        tx_builder.fee_rate(fee_rate).enable_rbf();
+        let (mut psbt, _tx_details) = tx_builder.finish().unwrap();
+        let _finalized = wallet.sign(&mut psbt, SignOptions::default()).unwrap();
+        let funding_tx = psbt.extract_tx();
+
+        let channels_to_open = requests_with_results
+            .iter()
+            .filter(|(_request, result, counterparty_node_id)| result.is_ok())
+            .count();
+
+        self.broadcaster
+            .set_debounce(funding_tx.txid(), channels_to_open);
+
+        requests_with_results
+            .into_iter()
+            .map(|(request, result, counterparty_node_id)| {
+                if let Ok(tcid) = result {
+                    let counterparty_node_id = counterparty_node_id.unwrap();
+                    match self
+                        .channel_manager
+                        .funding_transaction_generated(&tcid, &counterparty_node_id, funding_tx.clone())
+                    {
+                        Ok(()) => (request, result),
+                        Err(e) => (request, Err(Error::LdkApi(e))),
+                    }
+                } else {
+                    (request, result)
+                }
+            })
+            .collect()
+    }
+
+    fn initiate_channel_open(&self, request: &ChannelOpenRequest) -> Result<[u8; 32], Error> {
+        let config = UserConfig {
+            peer_channel_config_limits: ChannelHandshakeLimits {
+                // lnd's max to_self_delay is 2016, so we want to be compatible.
+                their_to_self_delay: 2016,
+                ..Default::default()
+            },
+            channel_options: ChannelConfig {
+                announced_channel: request.announced_channel,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // TODO: want to be logging channels in db for matching forwarded payments
+        match self.channel_manager.create_channel(
+            request.peer_pubkey,
+            request.channel_amt_sat,
+            request.push_amt_msat,
+            request.custom_id,
+            Some(config),
+        ) {
+            Ok(short_channel_id) => {
+                println!(
+                    "EVENT: initiated channel with peer {}. ",
+                    request.peer_pubkey
+                );
+                Ok(short_channel_id)
+            }
+            Err(e) => {
+                println!("ERROR: failed to open channel: {:?}", e);
+                Err(e.into())
+            }
+        }
+    }
+}

--- a/senseicore/src/database.rs
+++ b/senseicore/src/database.rs
@@ -114,6 +114,15 @@ impl SenseiDatabase {
             .await?)
     }
 
+    pub async fn list_ports_in_use(&self) -> Result<Vec<u16>, Error> {
+        Ok(Node::find()
+            .all(&self.connection)
+            .await?
+            .into_iter()
+            .map(|node| node.listen_port as u16)
+            .collect())
+    }
+
     pub async fn list_nodes(
         &self,
         pagination: PaginationRequest,

--- a/senseicore/src/database.rs
+++ b/senseicore/src/database.rs
@@ -22,7 +22,7 @@ use entity::sea_orm::QueryOrder;
 use migration::Condition;
 use migration::Expr;
 use rand::thread_rng;
-use rand::Rng;
+use rand::RngCore;
 use sea_orm::entity::EntityTrait;
 use sea_orm::{prelude::*, DatabaseConnection};
 use serde::Deserialize;

--- a/senseicore/src/error.rs
+++ b/senseicore/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
     InvalidMacaroon,
     AdminNodeNotStarted,
     AdminNodeNotCreated,
+    FundingGenerationNeverHappened,
 }
 
 impl Display for Error {
@@ -55,6 +56,9 @@ impl Display for Error {
             Error::InvalidMacaroon => String::from("invalid macaroon"),
             Error::AdminNodeNotCreated => String::from("admin node not created"),
             Error::AdminNodeNotStarted => String::from("admin node not started"),
+            Error::FundingGenerationNeverHappened => {
+                String::from("funding generation for request never happened")
+            }
         };
         write!(f, "{}", str)
     }

--- a/senseicore/src/event_handler.rs
+++ b/senseicore/src/event_handler.rs
@@ -79,7 +79,7 @@ impl EventHandler for LightningNodeEventHandler {
                         channel_value_satoshis: *channel_value_satoshis,
                         output_script: output_script.clone(),
                         user_channel_id: *user_channel_id,
-                        counterparty_node_id: *counterparty_node_id
+                        counterparty_node_id: *counterparty_node_id,
                     })
                     .unwrap();
             }

--- a/senseicore/src/events.rs
+++ b/senseicore/src/events.rs
@@ -1,7 +1,18 @@
-use bitcoin::Txid;
+use bitcoin::{Script, Txid, secp256k1::PublicKey};
 use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize)]
 pub enum SenseiEvent {
-    TransactionBroadcast { node_id: String, txid: Txid },
+    TransactionBroadcast {
+        node_id: String,
+        txid: Txid,
+    },
+    FundingGenerationReady {
+        node_id: String,
+        temporary_channel_id: [u8; 32],
+        channel_value_satoshis: u64,
+        output_script: Script,
+        user_channel_id: u64,
+        counterparty_node_id: PublicKey
+    },
 }

--- a/senseicore/src/events.rs
+++ b/senseicore/src/events.rs
@@ -1,4 +1,4 @@
-use bitcoin::{Script, Txid, secp256k1::PublicKey};
+use bitcoin::{secp256k1::PublicKey, Script, Txid};
 use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize)]
@@ -13,6 +13,6 @@ pub enum SenseiEvent {
         channel_value_satoshis: u64,
         output_script: Script,
         user_channel_id: u64,
-        counterparty_node_id: PublicKey
+        counterparty_node_id: PublicKey,
     },
 }

--- a/senseicore/src/lib.rs
+++ b/senseicore/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod chain;
+pub mod channels;
 pub mod config;
 pub mod database;
 pub mod disk;

--- a/senseicore/src/node.rs
+++ b/senseicore/src/node.rs
@@ -11,6 +11,7 @@ use crate::chain::broadcaster::SenseiBroadcaster;
 use crate::chain::database::WalletDatabase;
 use crate::chain::fee_estimator::SenseiFeeEstimator;
 use crate::chain::manager::SenseiChainManager;
+use crate::channels::{ChannelOpenRequest, ChannelOpener};
 use crate::config::SenseiConfig;
 use crate::database::SenseiDatabase;
 use crate::disk::FilesystemLogger;
@@ -19,7 +20,9 @@ use crate::event_handler::LightningNodeEventHandler;
 use crate::events::SenseiEvent;
 use crate::network_graph::OptionalNetworkGraphMsgHandler;
 use crate::persist::{AnyKVStore, DatabaseStore, SenseiPersister};
-use crate::services::node::{Channel, NodeInfo, NodeRequest, NodeRequestError, NodeResponse, Peer};
+use crate::services::node::{
+    Channel, NodeInfo, NodeRequest, NodeRequestError, NodeResponse, OpenChannelResult, Peer,
+};
 use crate::services::{PaginationRequest, PaginationResponse, PaymentsFilter};
 use crate::utils::PagedVec;
 use crate::{hex_utils, version};
@@ -62,7 +65,7 @@ use lightning_invoice::utils::DefaultRouter;
 use lightning_invoice::{payment, utils, Currency, Invoice, InvoiceDescription};
 use lightning_net_tokio::SocketDescriptor;
 use macaroon::Macaroon;
-use rand::{thread_rng, Rng};
+use rand::{thread_rng, Rng, RngCore};
 use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
 use std::fmt::Display;
 use std::fs::File;
@@ -407,6 +410,7 @@ pub struct LightningNode {
     pub stop_listen: Arc<AtomicBool>,
     pub persister: Arc<SenseiPersister>,
     pub event_sender: broadcast::Sender<SenseiEvent>,
+    pub broadcaster: Arc<SenseiBroadcaster>,
 }
 
 impl LightningNode {
@@ -634,12 +638,12 @@ impl LightningNode {
             fee_estimator: chain_manager.fee_estimator.clone(),
         });
 
-        let broadcaster = Arc::new(SenseiBroadcaster {
-            node_id: id.clone(),
-            broadcaster: chain_manager.broadcaster.clone(),
-            wallet_database: Arc::new(Mutex::new(wallet_database.clone())),
-            event_sender: event_sender.clone(),
-        });
+        let broadcaster = Arc::new(SenseiBroadcaster::new(
+            id.clone(),
+            chain_manager.broadcaster.clone(),
+            Arc::new(Mutex::new(wallet_database.clone())),
+            event_sender.clone(),
+        ));
 
         let persistence_store =
             AnyKVStore::Database(DatabaseStore::new(database.clone(), id.clone()));
@@ -880,6 +884,7 @@ impl LightningNode {
             stop_listen,
             persister,
             event_sender,
+            broadcaster,
         })
     }
 
@@ -1021,46 +1026,28 @@ impl LightningNode {
         (handles, background_processor)
     }
 
+    pub async fn open_channels(
+        &self,
+        requests: Vec<ChannelOpenRequest>,
+    ) -> Vec<(ChannelOpenRequest, Result<[u8; 32], Error>)> {
+        let mut opener = ChannelOpener::new(
+            self.id.clone(),
+            self.channel_manager.clone(),
+            self.chain_manager.clone(),
+            self.wallet.clone(),
+            self.event_sender.subscribe(),
+            self.broadcaster.clone(),
+        );
+        opener.open_batch(requests).await
+    }
+
     // `custom_id` will be user_channel_id in FundingGenerated event
     // allows use to tie the create_channel call with the event
-    pub fn open_channel(
-        &self,
-        peer_pubkey: PublicKey,
-        channel_amt_sat: u64,
-        push_amt_msat: u64,
-        custom_id: u64,
-        announced_channel: bool,
-    ) -> Result<[u8; 32], Error> {
-        let config = UserConfig {
-            peer_channel_config_limits: ChannelHandshakeLimits {
-                // lnd's max to_self_delay is 2016, so we want to be compatible.
-                their_to_self_delay: 2016,
-                ..Default::default()
-            },
-            channel_options: ChannelConfig {
-                announced_channel,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        // TODO: want to be logging channels in db for matching forwarded payments
-        match self.channel_manager.create_channel(
-            peer_pubkey,
-            channel_amt_sat,
-            push_amt_msat,
-            custom_id,
-            Some(config),
-        ) {
-            Ok(short_channel_id) => {
-                println!("EVENT: initiated channel with peer {}. ", peer_pubkey);
-                Ok(short_channel_id)
-            }
-            Err(e) => {
-                println!("ERROR: failed to open channel: {:?}", e);
-                Err(e.into())
-            }
-        }
+    pub async fn open_channel(&self, request: ChannelOpenRequest) -> Result<[u8; 32], Error> {
+        let requests = vec![request];
+        let mut responses = self.open_channels(requests).await;
+        let (_request, result) = responses.pop().unwrap();
+        result
     }
 
     pub async fn connect_to_peer(&self, pubkey: PublicKey, addr: SocketAddr) -> Result<(), Error> {
@@ -1470,37 +1457,59 @@ impl LightningNode {
                     balance_satoshis: balance,
                 })
             }
-            NodeRequest::OpenChannel {
-                node_connection_string,
-                amt_satoshis,
-                public,
-            } => {
-                let (pubkey, addr) = parse_peer_info(node_connection_string.clone()).await?;
+            NodeRequest::OpenChannels { channels } => {
+                let mut requests = vec![];
 
-                let found_peer = self
-                    .peer_manager
-                    .get_peer_node_ids()
-                    .into_iter()
-                    .find(|node_pubkey| *node_pubkey == pubkey);
-
-                if found_peer.is_none() {
-                    self.connect_to_peer(pubkey, addr).await?;
+                // TODO: i guess we need to filter out peers we couldn't connect to instead of unwrap()
+                for channel in &channels {
+                    let (pubkey, addr) = parse_peer_info(channel.node_connection_string.clone())
+                        .await
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "failed to parse connection string: {}",
+                                channel.node_connection_string
+                            )
+                        });
+                    connect_peer_if_necessary(pubkey, addr, self.peer_manager.clone())
+                        .await
+                        .unwrap_or_else(|_| {
+                            panic!("failed to connect to peer {}@{}", pubkey, addr)
+                        });
+                    requests.push(ChannelOpenRequest {
+                        node_connection_string: channel.node_connection_string.clone(),
+                        peer_pubkey: pubkey,
+                        channel_amt_sat: channel.amt_satoshis,
+                        push_amt_msat: 0,
+                        custom_id: thread_rng().gen_range(1..u64::MAX),
+                        announced_channel: channel.public,
+                    });
                 }
 
-                let res = self.open_channel(pubkey, amt_satoshis, 0, 0, public);
+                let responses = self.open_channels(requests).await;
 
-                match res {
-                    Ok(temp_channel_id) => {
-                        let _ = self.persister.persist_channel_peer(&node_connection_string);
-                        Ok(NodeResponse::OpenChannel {
-                            temp_channel_id: hex_utils::hex_str(&temp_channel_id),
+                Ok(NodeResponse::OpenChannels {
+                    channels,
+                    results: responses
+                        .into_iter()
+                        .map(|(request, result)| match result {
+                            Ok(temp_channel_id) => {
+                                let _ = self
+                                    .persister
+                                    .persist_channel_peer(&request.node_connection_string);
+                                OpenChannelResult {
+                                    error: false,
+                                    error_message: None,
+                                    temp_channel_id: Some(hex_utils::hex_str(&temp_channel_id)),
+                                }
+                            }
+                            Err(e) => OpenChannelResult {
+                                error: true,
+                                error_message: Some(e.to_string()),
+                                temp_channel_id: None,
+                            },
                         })
-                    }
-                    Err(e) => Ok(NodeResponse::Error(NodeRequestError::Sensei(format!(
-                        "Failed to open channel: {:?}",
-                        e
-                    )))),
-                }
+                        .collect::<Vec<_>>(),
+                })
             }
             NodeRequest::SendPayment { invoice } => {
                 let invoice = self.get_invoice_from_str(&invoice)?;

--- a/senseicore/src/node.rs
+++ b/senseicore/src/node.rs
@@ -58,7 +58,7 @@ use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning::routing::network_graph::{NetGraphMsgHandler, NetworkGraph, NodeId, RoutingFees};
 use lightning::routing::router::{RouteHint, RouteHintHop};
 use lightning::routing::scoring::ProbabilisticScorer;
-use lightning::util::config::{ChannelConfig, ChannelHandshakeLimits, UserConfig};
+use lightning::util::config::UserConfig;
 use lightning::util::ser::ReadableArgs;
 use lightning_background_processor::BackgroundProcessor;
 use lightning_invoice::utils::DefaultRouter;

--- a/senseicore/src/services/node.rs
+++ b/senseicore/src/services/node.rs
@@ -17,7 +17,7 @@ use tower::Service;
 use crate::hex_utils;
 
 use lightning::ln::channelmanager::ChannelDetails;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{PaginationRequest, PaginationResponse, PaymentsFilter};
 
@@ -115,6 +115,20 @@ impl From<ChannelDetails> for Channel {
     }
 }
 
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct OpenChannelInfo {
+    pub node_connection_string: String,
+    pub amt_satoshis: u64,
+    pub public: bool,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct OpenChannelResult {
+    pub error: bool,
+    pub error_message: Option<String>,
+    pub temp_channel_id: Option<String>,
+}
+
 pub enum NodeRequest {
     StartNode {
         passphrase: String,
@@ -122,10 +136,8 @@ pub enum NodeRequest {
     StopNode {},
     GetUnusedAddress {},
     GetBalance {},
-    OpenChannel {
-        node_connection_string: String,
-        amt_satoshis: u64,
-        public: bool,
+    OpenChannels {
+        channels: Vec<OpenChannelInfo>,
     },
     SendPayment {
         invoice: String,
@@ -187,8 +199,9 @@ pub enum NodeResponse {
     GetBalance {
         balance_satoshis: u64,
     },
-    OpenChannel {
-        temp_channel_id: String,
+    OpenChannels {
+        channels: Vec<OpenChannelInfo>,
+        results: Vec<OpenChannelResult>,
     },
     SendPayment {},
     DecodeInvoice {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,8 +21,8 @@ use tonic::{metadata::MetadataValue, transport::Channel, Request};
 use crate::sensei::{
     CloseChannelRequest, ConnectPeerRequest, CreateAdminRequest, CreateInvoiceRequest,
     CreateNodeRequest, GetUnusedAddressRequest, InfoRequest, KeysendRequest, ListChannelsRequest,
-    ListNodesRequest, ListPaymentsRequest, ListPeersRequest, OpenChannelRequest, PayInvoiceRequest,
-    SignMessageRequest, StartAdminRequest, StartNodeRequest,
+    ListNodesRequest, ListPaymentsRequest, ListPeersRequest, OpenChannelInfo, OpenChannelsRequest,
+    PayInvoiceRequest, SignMessageRequest, StartAdminRequest, StartNodeRequest,
 };
 
 pub mod sensei {
@@ -340,13 +340,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .parse()
                     .expect("public must be true or false");
 
-                let request = tonic::Request::new(OpenChannelRequest {
-                    node_connection_string: node_connection_string.to_string(),
-                    amt_satoshis,
-                    public,
+                let request = tonic::Request::new(OpenChannelsRequest {
+                    channels: vec![OpenChannelInfo {
+                        node_connection_string: node_connection_string.to_string(),
+                        amt_satoshis,
+                        public,
+                    }],
                 });
 
-                let response = client.open_channel(request).await?;
+                let response = client.open_channels(request).await?;
                 println!("{:?}", response.into_inner());
             }
             "closechannel" => {

--- a/src/grpc/node.rs
+++ b/src/grpc/node.rs
@@ -19,7 +19,7 @@ use super::{
         GetUnusedAddressRequest, GetUnusedAddressResponse, InfoRequest, InfoResponse,
         KeysendRequest, KeysendResponse, LabelPaymentRequest, LabelPaymentResponse,
         ListChannelsRequest, ListChannelsResponse, ListPaymentsRequest, ListPaymentsResponse,
-        ListPeersRequest, ListPeersResponse, OpenChannelRequest, OpenChannelResponse,
+        ListPeersRequest, ListPeersResponse, OpenChannelsRequest, OpenChannelsResponse,
         PayInvoiceRequest, PayInvoiceResponse, SignMessageRequest, SignMessageResponse,
         StartNodeRequest, StartNodeResponse, StopNodeRequest, StopNodeResponse,
         VerifyMessageRequest, VerifyMessageResponse,
@@ -143,10 +143,10 @@ impl Node for NodeService {
             .map(Response::new)
             .map_err(|_e| Status::unknown("unknown error"))
     }
-    async fn open_channel(
+    async fn open_channels(
         &self,
-        request: tonic::Request<OpenChannelRequest>,
-    ) -> Result<tonic::Response<OpenChannelResponse>, tonic::Status> {
+        request: tonic::Request<OpenChannelsRequest>,
+    ) -> Result<tonic::Response<OpenChannelsResponse>, tonic::Status> {
         self.authenticated_request(request.metadata().clone(), request.into_inner().into())
             .await?
             .try_into()

--- a/src/http/admin.rs
+++ b/src/http/admin.rs
@@ -372,13 +372,16 @@ pub async fn login(
                             .http_only(true)
                             .finish();
                         cookies.add(macaroon_cookie);
-                        let token_cookie = Cookie::build("token", token).http_only(true).finish();
+                        let token_cookie = Cookie::build("token", token.clone())
+                            .http_only(true)
+                            .finish();
                         cookies.add(token_cookie);
                         Ok(Json(json!({
                             "pubkey": node.pubkey,
                             "alias": node.alias,
                             "macaroon": macaroon,
                             "role": node.role as u16,
+                            "token": token
                         })))
                     }
                     _ => Err(StatusCode::UNPROCESSABLE_ENTITY),

--- a/system-tests/system-test.py
+++ b/system-tests/system-test.py
@@ -19,7 +19,7 @@ from sensei_pb2_grpc import AdminStub, NodeStub
 from sensei_pb2 import (
     CloseChannelRequest, GetStatusRequest, CreateNodeRequest, GetUnusedAddressRequest,
     GetBalanceRequest,
-    ListPaymentsRequest, OpenChannelRequest, ListChannelsRequest, CreateInvoiceRequest,
+    ListPaymentsRequest, OpenChannelsRequest, OpenChannelInfo, ListChannelsRequest, CreateInvoiceRequest,
     PaginationRequest, PayInvoiceRequest
 )
 
@@ -148,15 +148,17 @@ def run():
     bob, meta_b, id_b = fund_node(btc, metadata, senseid, 1)
 
     print('Create channel alice -> bob')
-    alice.OpenChannel(OpenChannelRequest(node_connection_string=f"{id_b}@127.0.0.1:10000", amt_satoshis=CHANNEL_VALUE_SAT, public=True),
+    oc_res = alice.OpenChannels(OpenChannelsRequest(channels=[OpenChannelInfo(node_connection_string=f"{id_b}@127.0.0.1:10000", amt_satoshis=CHANNEL_VALUE_SAT, public=True)]),
                       metadata=meta_a)
+
+    print(oc_res)
     wait_until('channel at bob', lambda: bob.ListChannels(ListChannelsRequest(), metadata=meta_b).channels[0])
     assert not bob.ListChannels(ListChannelsRequest(), metadata=meta_b).channels[0].is_usable
 
     charlie, meta_c, id_c = fund_node(btc, metadata, senseid, 2)
 
     print('Create channel bob -> charlie')
-    bob.OpenChannel(OpenChannelRequest(node_connection_string=f"{id_c}@127.0.0.1:10001", amt_satoshis=CHANNEL_VALUE_SAT, public=True),
+    bob.OpenChannels(OpenChannelsRequest(channels=[OpenChannelInfo(node_connection_string=f"{id_c}@127.0.0.1:10001", amt_satoshis=CHANNEL_VALUE_SAT, public=True)]),
                     metadata=meta_b)
     wait_until('channel at charlie', lambda: charlie.ListChannels(ListChannelsRequest(), metadata=meta_c).channels[0])
     assert not charlie.ListChannels(ListChannelsRequest(), metadata=meta_c).channels[0].is_usable

--- a/web-admin/package-lock.json
+++ b/web-admin/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^1.4.2",
         "@heroicons/react": "^1.0.5",
-        "@l2-technology/sensei-client": "^0.1.8",
+        "@l2-technology/sensei-client": "^0.1.14",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.4.0",
         "@tailwindcss/typography": "^0.5.0",
@@ -3189,12 +3189,9 @@
       }
     },
     "node_modules/@l2-technology/sensei-client": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.8.tgz",
-      "integrity": "sha512-nxtn0G7tS0MlCT/16HPssxiqCAucycc3msR+P78+gZ4sTIg/fnmgefg0HAYWBfjUr37VD9VjVN6pUwYXPuHlew==",
-      "dependencies": {
-        "cross-fetch": "^3.1.5"
-      }
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.14.tgz",
+      "integrity": "sha512-d9D0rXjSLiwcwLgO1JU6JvZ5/Plo7H/QNYuEzsONudWvpy9j5KYTUCE9tkioxom/LloddMQkU8ilH4BsJcGEWw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8156,14 +8153,6 @@
         "node": ">=10.14",
         "npm": ">=6",
         "yarn": ">=1"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dependencies": {
-        "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
@@ -16733,6 +16722,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -16751,17 +16741,20 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -25929,12 +25922,9 @@
       }
     },
     "@l2-technology/sensei-client": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.8.tgz",
-      "integrity": "sha512-nxtn0G7tS0MlCT/16HPssxiqCAucycc3msR+P78+gZ4sTIg/fnmgefg0HAYWBfjUr37VD9VjVN6pUwYXPuHlew==",
-      "requires": {
-        "cross-fetch": "^3.1.5"
-      }
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.14.tgz",
+      "integrity": "sha512-d9D0rXjSLiwcwLgO1JU6JvZ5/Plo7H/QNYuEzsONudWvpy9j5KYTUCE9tkioxom/LloddMQkU8ilH4BsJcGEWw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -29706,14 +29696,6 @@
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.1"
-      }
-    },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "requires": {
-        "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {
@@ -36160,6 +36142,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -36167,17 +36150,20 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "peer": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "peer": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "peer": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"

--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.2",
     "@heroicons/react": "^1.0.5",
-    "@l2-technology/sensei-client": "^0.1.8",
+    "@l2-technology/sensei-client": "^0.1.14",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/typography": "^0.5.0",


### PR DESCRIPTION
Adds a `ChannelOpener` struct that orchestrates batch channel opens.  A batch channel open is one where you can open multiple channels using a single on-chain transaction.

Right now LDK doesn't "officially" support this (https://github.com/lightningdevkit/rust-lightning/issues/1510) but was able to work around these issues with a few workarounds.

Added a new NodeRequest::OpenChannels that lets you provide a Vec of channels to open.  Also updated NodeRequest::OpenChannel to use batch channel open flow with a batch of size 1.

The [wip] part of this is around the actual API.  Right now there is no actual api exposed.  The other issue is around how to handle (and respond) when _some_ of the channels fail to open for whatever reason.

Right now the workflow keeps track of all open requests individually and the plan is to return list of tuples like this: Vec<(open_request,open_result)>