### PR TITLE
Add listunspent command for seeing on-chain utxos

### DIFF
--- a/proto/sensei.proto
+++ b/proto/sensei.proto
@@ -35,6 +35,7 @@ service Node {
     rpc ListPeers (ListPeersRequest) returns (ListPeersResponse);
     rpc SignMessage (SignMessageRequest) returns (SignMessageResponse);
     rpc VerifyMessage (VerifyMessageRequest) returns (VerifyMessageResponse);
+    rpc ListUnspent (ListUnspentRequest) returns (ListUnspentResponse);
 }
 
 message ListNode {
@@ -381,4 +382,16 @@ message VerifyMessageRequest {
 message VerifyMessageResponse {
     bool valid = 1;
     string pubkey = 2;
+}
+message ListUnspentRequest {}
+
+message Utxo {
+    uint64 amount_sat = 1;
+    string spk = 2;
+    string txid = 3;
+    uint32 output_index = 4;
+}
+
+message ListUnspentResponse {
+    repeated Utxo utxos = 1;
 }

--- a/senseicore/src/services/node.rs
+++ b/senseicore/src/services/node.rs
@@ -129,6 +129,14 @@ pub struct OpenChannelResult {
     pub temp_channel_id: Option<String>,
 }
 
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Utxo {
+    pub amount_sat: u64,
+    pub spk: String,
+    pub txid: String,
+    pub output_index: u32,
+}
+
 pub enum NodeRequest {
     StartNode {
         passphrase: String,
@@ -186,6 +194,7 @@ pub enum NodeRequest {
         message: String,
         signature: String,
     },
+    ListUnspent {},
 }
 
 #[derive(Serialize)]
@@ -239,6 +248,9 @@ pub enum NodeResponse {
     VerifyMessage {
         valid: bool,
         pubkey: String,
+    },
+    ListUnspent {
+        utxos: Vec<Utxo>,
     },
     Error(NodeRequestError),
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,8 +21,9 @@ use tonic::{metadata::MetadataValue, transport::Channel, Request};
 use crate::sensei::{
     CloseChannelRequest, ConnectPeerRequest, CreateAdminRequest, CreateInvoiceRequest,
     CreateNodeRequest, GetUnusedAddressRequest, InfoRequest, KeysendRequest, ListChannelsRequest,
-    ListNodesRequest, ListPaymentsRequest, ListPeersRequest, OpenChannelInfo, OpenChannelsRequest,
-    PayInvoiceRequest, SignMessageRequest, StartAdminRequest, StartNodeRequest,
+    ListNodesRequest, ListPaymentsRequest, ListPeersRequest, ListUnspentRequest, OpenChannelInfo,
+    OpenChannelsRequest, PayInvoiceRequest, SignMessageRequest, StartAdminRequest,
+    StartNodeRequest,
 };
 
 pub mod sensei {
@@ -443,6 +444,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "listpeers" => {
                 let request = tonic::Request::new(ListPeersRequest {});
                 let response = client.list_peers(request).await?;
+                println!("{:?}", response.into_inner());
+            }
+            "listunspent" => {
+                let request = tonic::Request::new(ListUnspentRequest {});
+                let response = client.list_unspent(request).await?;
                 println!("{:?}", response.into_inner());
             }
             "nodeinfo" => {

--- a/src/grpc/node.rs
+++ b/src/grpc/node.rs
@@ -19,10 +19,10 @@ use super::{
         GetUnusedAddressRequest, GetUnusedAddressResponse, InfoRequest, InfoResponse,
         KeysendRequest, KeysendResponse, LabelPaymentRequest, LabelPaymentResponse,
         ListChannelsRequest, ListChannelsResponse, ListPaymentsRequest, ListPaymentsResponse,
-        ListPeersRequest, ListPeersResponse, OpenChannelsRequest, OpenChannelsResponse,
-        PayInvoiceRequest, PayInvoiceResponse, SignMessageRequest, SignMessageResponse,
-        StartNodeRequest, StartNodeResponse, StopNodeRequest, StopNodeResponse,
-        VerifyMessageRequest, VerifyMessageResponse,
+        ListPeersRequest, ListPeersResponse, ListUnspentRequest, ListUnspentResponse,
+        OpenChannelsRequest, OpenChannelsResponse, PayInvoiceRequest, PayInvoiceResponse,
+        SignMessageRequest, SignMessageResponse, StartNodeRequest, StartNodeResponse,
+        StopNodeRequest, StopNodeResponse, VerifyMessageRequest, VerifyMessageResponse,
     },
     utils::raw_macaroon_from_metadata,
 };
@@ -288,6 +288,16 @@ impl Node for NodeService {
         &self,
         request: tonic::Request<VerifyMessageRequest>,
     ) -> Result<tonic::Response<VerifyMessageResponse>, tonic::Status> {
+        self.authenticated_request(request.metadata().clone(), request.into_inner().into())
+            .await?
+            .try_into()
+            .map(Response::new)
+            .map_err(|_e| Status::unknown("unknown error"))
+    }
+    async fn list_unspent(
+        &self,
+        request: tonic::Request<ListUnspentRequest>,
+    ) -> Result<tonic::Response<ListUnspentResponse>, tonic::Status> {
         self.authenticated_request(request.metadata().clone(), request.into_inner().into())
             .await?
             .try_into()

--- a/src/http/node.rs
+++ b/src/http/node.rs
@@ -196,6 +196,7 @@ pub fn add_routes(router: Router) -> Router {
         .route("/v1/node/payments", get(handle_get_payments))
         .route("/v1/node/wallet/address", get(get_unused_address))
         .route("/v1/node/wallet/balance", get(get_wallet_balance))
+        .route("/v1/node/wallet/utxos", get(list_unspent))
         .route("/v1/node/channels", get(get_channels))
         .route("/v1/node/transactions", get(get_transactions))
         .route("/v1/node/info", get(get_info))
@@ -557,4 +558,18 @@ pub async fn verify_message(
         }
     }?;
     handle_authenticated_request(admin_service, request, macaroon, cookies).await
+}
+
+pub async fn list_unspent(
+    Extension(admin_service): Extension<Arc<AdminService>>,
+    AuthHeader { macaroon, token: _ }: AuthHeader,
+    cookies: Cookies,
+) -> Result<Json<NodeResponse>, StatusCode> {
+    handle_authenticated_request(
+        admin_service,
+        NodeRequest::ListUnspent {},
+        macaroon,
+        cookies,
+    )
+    .await
 }


### PR DESCRIPTION
Creates a command `listunspent` that returns the wallet's current on-chain utxos.

Example output

```json
{
  "utxos": [
    {
      "amount_sat": 200000,
      "spk": "0014caceda7dbbe834baa275f7eedefe4b3c7c8d3f9d",
      "txid": "f882c1acf8d5bfa5d6da6ed7fbcbc6d5888768e01806dbe55b941dd5417c1308",
      "output_index": 0
    },
    {
      "amount_sat": 72000,
      "spk": "0014caceda7dbbe834baa275f7eedefe4b3c7c8d3f9d",
      "txid": "18ec7ed22bbd4f4fb2f19a240d6b8dcf296cf28c9ce057319248235fe1056545",
      "output_index": 1
    },
    {
      "amount_sat": 50000,
      "spk": "0014caceda7dbbe834baa275f7eedefe4b3c7c8d3f9d",
      "txid": "a600c53d0f81c5643572f98ed2b14204bb716c9b44a0b2abc204a8563b794b70",
      "output_index": 0
    }
  ]
}
```