### PR TITLE
0-conf channel implementation w/ peer directory

### DIFF
--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -10,6 +10,7 @@ pub mod kv_store;
 pub mod macaroon;
 pub mod node;
 pub mod payment;
+pub mod peer;
 pub mod script_pubkey;
 pub mod transaction;
 pub mod utxo;

--- a/entity/src/peer.rs
+++ b/entity/src/peer.rs
@@ -1,0 +1,88 @@
+use sea_orm::{entity::prelude::*, ActiveValue};
+
+use crate::seconds_since_epoch;
+
+#[derive(Copy, Clone, Default, Debug, DeriveEntity)]
+pub struct Entity;
+
+impl EntityName for Entity {
+    fn table_name(&self) -> &str {
+        "peer"
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, DeriveModel, DeriveActiveModel)]
+pub struct Model {
+    pub id: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub node_id: String,
+    pub pubkey: String,
+    pub label: String,
+    pub zero_conf: bool,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
+pub enum Column {
+    Id,
+    CreatedAt,
+    UpdatedAt,
+    NodeId,
+    Pubkey,
+    Label,
+    ZeroConf,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
+pub enum PrimaryKey {
+    Id,
+}
+
+impl PrimaryKeyTrait for PrimaryKey {
+    type ValueType = String;
+    fn auto_increment() -> bool {
+        false
+    }
+}
+
+#[derive(Copy, Clone, Debug, EnumIter)]
+pub enum Relation {}
+
+impl ColumnTrait for Column {
+    type EntityName = Entity;
+    fn def(&self) -> ColumnDef {
+        match self {
+            Self::Id => ColumnType::String(None).def().unique(),
+            Self::CreatedAt => ColumnType::BigInteger.def(),
+            Self::UpdatedAt => ColumnType::BigInteger.def(),
+            Self::NodeId => ColumnType::String(None).def(),
+            Self::Pubkey => ColumnType::String(None).def(),
+            Self::Label => ColumnType::String(None).def(),
+            Self::ZeroConf => ColumnType::Boolean.def(),
+        }
+    }
+}
+
+impl RelationTrait for Relation {
+    fn def(&self) -> RelationDef {
+        panic!("No RelationDef")
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {
+    fn new() -> Self {
+        Self {
+            id: ActiveValue::Set(Uuid::new_v4().to_string()),
+            ..<Self as ActiveModelTrait>::default()
+        }
+    }
+
+    fn before_save(mut self, insert: bool) -> Result<Self, DbErr> {
+        let now: i64 = seconds_since_epoch();
+        self.updated_at = ActiveValue::Set(now);
+        if insert {
+            self.created_at = ActiveValue::Set(now);
+        }
+        Ok(self)
+    }
+}

--- a/entity/src/peer.rs
+++ b/entity/src/peer.rs
@@ -1,4 +1,5 @@
 use sea_orm::{entity::prelude::*, ActiveValue};
+use serde::{Deserialize, Serialize};
 
 use crate::seconds_since_epoch;
 
@@ -11,15 +12,15 @@ impl EntityName for Entity {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, DeriveModel, DeriveActiveModel)]
+#[derive(Clone, Debug, PartialEq, DeriveModel, DeriveActiveModel, Deserialize, Serialize)]
 pub struct Model {
     pub id: String,
     pub created_at: i64,
     pub updated_at: i64,
     pub node_id: String,
     pub pubkey: String,
-    pub label: String,
     pub zero_conf: bool,
+    pub label: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -9,6 +9,7 @@ mod m20220428_000001_create_utxos_table;
 mod m20220428_000002_create_script_pubkeys_table;
 mod m20220428_000003_create_transactions_table;
 mod m20220428_000004_create_keychains_table;
+mod m20220616_000001_create_peers_table;
 
 pub struct Migrator;
 
@@ -26,6 +27,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20220428_000002_create_script_pubkeys_table::Migration),
             Box::new(m20220428_000003_create_transactions_table::Migration),
             Box::new(m20220428_000004_create_keychains_table::Migration),
+            Box::new(m20220616_000001_create_peers_table::Migration),
         ]
     }
 }

--- a/migration/src/m20220616_000001_create_peers_table.rs
+++ b/migration/src/m20220616_000001_create_peers_table.rs
@@ -1,0 +1,59 @@
+use sea_schema::migration::prelude::*;
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20220616_000001_create_peers_table"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let _res = manager
+            .create_table(
+                Table::create()
+                    .table(Peer::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Peer::Id).string().not_null().primary_key())
+                    .col(ColumnDef::new(Peer::CreatedAt).big_integer().not_null())
+                    .col(ColumnDef::new(Peer::UpdatedAt).big_integer().not_null())
+                    .col(ColumnDef::new(Peer::NodeId).string().not_null())
+                    .col(ColumnDef::new(Peer::Pubkey).string().not_null())
+                    .col(ColumnDef::new(Peer::Label).string())
+                    .col(ColumnDef::new(Peer::ZeroConf).boolean().not_null())
+                    .to_owned(),
+            )
+            .await;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Peer::Table)
+                    .name("idx-nodeid-pubkey")
+                    .col(Peer::NodeId)
+                    .col(Peer::Pubkey)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let mut drop_table_stmt = Table::drop();
+        drop_table_stmt.table(Peer::Table);
+        manager.drop_table(drop_table_stmt).await
+    }
+}
+
+#[derive(Iden)]
+enum Peer {
+    Table,
+    Id,
+    CreatedAt,
+    UpdatedAt,
+    NodeId,
+    Pubkey,
+    Label,
+    ZeroConf,
+}

--- a/proto/sensei.proto
+++ b/proto/sensei.proto
@@ -37,6 +37,9 @@ service Node {
     rpc VerifyMessage (VerifyMessageRequest) returns (VerifyMessageResponse);
     rpc ListUnspent (ListUnspentRequest) returns (ListUnspentResponse);
     rpc NetworkGraphInfo (NetworkGraphInfoRequest) returns (NetworkGraphInfoResponse);
+    rpc ListKnownPeers (ListKnownPeersRequest) returns (ListKnownPeersResponse);
+    rpc AddKnownPeer (AddKnownPeerRequest) returns (AddKnownPeerResponse);
+    rpc RemoveKnownPeer (RemoveKnownPeerRequest) returns (RemoveKnownPeerResponse);
 }
 
 message ListNode {
@@ -416,4 +419,29 @@ message NetworkGraphInfoResponse {
     uint64 num_channels = 1;
     uint64 num_nodes = 2;
     uint64 num_known_edge_policies = 3;
+}
+
+message AddKnownPeerRequest {
+    string pubkey = 1;
+    string label = 2;
+    bool zero_conf = 3;
+}
+message AddKnownPeerResponse {}
+
+message RemoveKnownPeerRequest {
+    string pubkey = 1;
+}
+message RemoveKnownPeerResponse {}
+
+message KnownPeer {
+    string pubkey = 1;
+    optional string label = 2;
+    bool zero_conf = 3;
+}
+message ListKnownPeersRequest {
+    optional PaginationRequest pagination = 1;
+}
+message ListKnownPeersResponse {
+    repeated KnownPeer peers = 1;
+    PaginationResponse pagination = 2;
 }

--- a/senseicore/src/database.rs
+++ b/senseicore/src/database.rs
@@ -401,7 +401,7 @@ impl SenseiDatabase {
     pub fn find_peer_sync(
         &self,
         node_id: &str,
-        pubkey: &str
+        pubkey: &str,
     ) -> Result<Option<peer::Model>, Error> {
         tokio::task::block_in_place(move || {
             self.runtime_handle
@@ -423,7 +423,7 @@ impl SenseiDatabase {
             .filter(
                 Condition::any()
                     .add(peer::Column::Pubkey.contains(&query_string))
-                    .add(peer::Column::Label.contains(&query_string))
+                    .add(peer::Column::Label.contains(&query_string)),
             )
             .order_by_desc(peer::Column::CreatedAt)
             .paginate(&self.connection, page_size);

--- a/senseicore/src/database.rs
+++ b/senseicore/src/database.rs
@@ -425,7 +425,7 @@ impl SenseiDatabase {
                     .add(peer::Column::Pubkey.contains(&query_string))
                     .add(peer::Column::Label.contains(&query_string))
             )
-            .order_by_desc(peer::Column::UpdatedAt)
+            .order_by_desc(peer::Column::CreatedAt)
             .paginate(&self.connection, page_size);
 
         let peers = peer_pages.fetch_page(page).await?;

--- a/senseicore/src/error.rs
+++ b/senseicore/src/error.rs
@@ -14,6 +14,7 @@ use std::{
 
 #[derive(Debug)]
 pub enum Error {
+    Generic(String),
     Db(migration::DbErr),
     TinderCrypt(tindercrypt::errors::Error),
     Macaroon(macaroon::MacaroonError),
@@ -41,6 +42,7 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str = match self {
+            Error::Generic(e) => e.to_string(),
             Error::Db(e) => e.to_string(),
             Error::Macaroon(_e) => "macaroon error".to_string(),
             Error::TinderCrypt(e) => e.to_string(),

--- a/senseicore/src/event_handler.rs
+++ b/senseicore/src/event_handler.rs
@@ -54,10 +54,12 @@ impl EventHandler for LightningNodeEventHandler {
                 counterparty_node_id,
                 funding_satoshis: _,
                 push_msat: _,
-                channel_type,
+                channel_type: _,
             } => {
-                // TODO: lookup counterparty_node_id in my trusted peer list to set this
-                let is_trusted_peer = true;
+                let is_trusted_peer = match self.database.find_peer_sync(&self.node_id, &counterparty_node_id.to_string()) {
+                    Ok(Some(known_peer)) => known_peer.zero_conf,
+                    _ => false
+                };
 
                 if is_trusted_peer {
                     match self

--- a/senseicore/src/event_handler.rs
+++ b/senseicore/src/event_handler.rs
@@ -49,8 +49,54 @@ pub struct LightningNodeEventHandler {
 impl EventHandler for LightningNodeEventHandler {
     fn handle_event(&self, event: &Event) {
         match event {
-            Event::OpenChannelRequest { .. } => {
-                // Unreachable, we don't set manually_accept_inbound_channels
+            Event::OpenChannelRequest {
+                temporary_channel_id,
+                counterparty_node_id,
+                funding_satoshis: _,
+                push_msat: _,
+                channel_type,
+            } => {
+                // TODO: lookup counterparty_node_id in my trusted peer list to set this
+                let is_trusted_peer = true;
+
+                if is_trusted_peer {
+                    match self
+                        .channel_manager
+                        .accept_inbound_channel_from_trusted_peer_0conf(
+                            temporary_channel_id,
+                            counterparty_node_id,
+                            1,
+                        ) {
+                        Ok(()) => {
+                            println!(
+                                "accepted 0-conf inbound channel from {:?}",
+                                counterparty_node_id
+                            );
+                        }
+                        Err(e) => {
+                            println!(
+                                "failed to accept 0-conf inbound channel from {:?}: {:?}",
+                                counterparty_node_id, e
+                            );
+                        }
+                    }
+                } else {
+                    match self.channel_manager.accept_inbound_channel(
+                        temporary_channel_id,
+                        counterparty_node_id,
+                        1,
+                    ) {
+                        Ok(()) => {
+                            println!("accepted inbound channel from {:?}", counterparty_node_id);
+                        }
+                        Err(e) => {
+                            println!(
+                                "failed to accept inbound channel from {:?}: {:?}",
+                                counterparty_node_id, e
+                            );
+                        }
+                    }
+                }
             }
             Event::FundingGenerationReady {
                 temporary_channel_id,

--- a/senseicore/src/event_handler.rs
+++ b/senseicore/src/event_handler.rs
@@ -56,9 +56,12 @@ impl EventHandler for LightningNodeEventHandler {
                 push_msat: _,
                 channel_type: _,
             } => {
-                let is_trusted_peer = match self.database.find_peer_sync(&self.node_id, &counterparty_node_id.to_string()) {
+                let is_trusted_peer = match self
+                    .database
+                    .find_peer_sync(&self.node_id, &counterparty_node_id.to_string())
+                {
                     Ok(Some(known_peer)) => known_peer.zero_conf,
-                    _ => false
+                    _ => false,
                 };
 
                 if is_trusted_peer {

--- a/senseicore/src/node.rs
+++ b/senseicore/src/node.rs
@@ -629,9 +629,11 @@ impl LightningNode {
 
         // TODO: likely expose a lot of this config to our LightningNodeConfig
         let mut user_config = UserConfig::default();
+
         user_config
             .peer_channel_config_limits
             .force_announced_channel_preference = false;
+        user_config.manually_accept_inbound_channels = true;
 
         let best_block = chain_manager.get_best_block().await?;
 

--- a/senseicore/src/node.rs
+++ b/senseicore/src/node.rs
@@ -1667,19 +1667,23 @@ impl LightningNode {
                     num_nodes: graph.nodes().len() as u64,
                     num_known_edge_policies,
                 })
-            },
+            }
             NodeRequest::ListKnownPeers { pagination } => {
                 let (peers, pagination) = self.database.list_peers(&self.id, pagination).await?;
                 Ok(NodeResponse::ListKnownPeers { peers, pagination })
             }
-            NodeRequest::AddKnownPeer { pubkey, label, zero_conf } => {
+            NodeRequest::AddKnownPeer {
+                pubkey,
+                label,
+                zero_conf,
+            } => {
                 let peer = match self.database.find_peer(&self.id, &pubkey).await? {
                     Some(peer) => {
                         let mut peer: entity::peer::ActiveModel = peer.into();
                         peer.label = ActiveValue::Set(Some(label));
                         peer.zero_conf = ActiveValue::Set(zero_conf);
                         peer.update(self.database.get_connection())
-                    },
+                    }
                     None => {
                         let peer = entity::peer::ActiveModel {
                             node_id: ActiveValue::Set(self.id.clone()),
@@ -1692,7 +1696,7 @@ impl LightningNode {
                     }
                 };
 
-                let _res = peer.await.map_err(|e| Error::Db(e))?;
+                let _res = peer.await.map_err(Error::Db)?;
 
                 Ok(NodeResponse::AddKnownPeer {})
             }

--- a/senseicore/src/services/mod.rs
+++ b/senseicore/src/services/mod.rs
@@ -158,7 +158,6 @@ impl From<ListTransactionsParams> for PaginationRequest {
     }
 }
 
-
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ListKnownPeersParams {
     pub page: u32,

--- a/senseicore/src/services/mod.rs
+++ b/senseicore/src/services/mod.rs
@@ -158,6 +158,35 @@ impl From<ListTransactionsParams> for PaginationRequest {
     }
 }
 
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ListKnownPeersParams {
+    pub page: u32,
+    pub take: u32,
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    pub query: Option<String>,
+}
+
+impl Default for ListKnownPeersParams {
+    fn default() -> Self {
+        Self {
+            page: 0,
+            take: 10,
+            query: None,
+        }
+    }
+}
+
+impl From<ListKnownPeersParams> for PaginationRequest {
+    fn from(params: ListKnownPeersParams) -> Self {
+        Self {
+            page: params.page,
+            take: params.take,
+            query: params.query,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PaginationResponse {
     pub has_more: bool,

--- a/senseicore/src/services/node.rs
+++ b/senseicore/src/services/node.rs
@@ -138,6 +138,7 @@ impl From<&OpenChannelRequest> for UserConfig {
             peer_channel_config_limits: ChannelHandshakeLimits {
                 // lnd's max to_self_delay is 2016, so we want to be compatible.
                 their_to_self_delay: 2016,
+                trust_own_funding_0conf: true,
                 ..Default::default()
             },
             channel_options: ChannelConfig {

--- a/senseicore/src/services/node.rs
+++ b/senseicore/src/services/node.rs
@@ -239,6 +239,17 @@ pub enum NodeRequest {
     },
     ListUnspent {},
     NetworkGraphInfo {},
+    ListKnownPeers {
+        pagination: PaginationRequest,
+    },
+    AddKnownPeer {
+        pubkey: String,
+        label: String,
+        zero_conf: bool
+    },
+    RemoveKnownPeer {
+        pubkey: String
+    },
 }
 
 #[derive(Serialize)]
@@ -306,6 +317,12 @@ pub enum NodeResponse {
         num_nodes: u64,
         num_known_edge_policies: u64,
     },
+    ListKnownPeers {
+        peers: Vec<entity::peer::Model>,
+        pagination: PaginationResponse,
+    },
+    AddKnownPeer {},
+    RemoveKnownPeer {},
     Error(NodeRequestError),
 }
 

--- a/senseicore/src/services/node.rs
+++ b/senseicore/src/services/node.rs
@@ -245,10 +245,10 @@ pub enum NodeRequest {
     AddKnownPeer {
         pubkey: String,
         label: String,
-        zero_conf: bool
+        zero_conf: bool,
     },
     RemoveKnownPeer {
-        pubkey: String
+        pubkey: String,
     },
 }
 

--- a/src/grpc/adaptor.rs
+++ b/src/grpc/adaptor.rs
@@ -13,7 +13,7 @@ use super::sensei::{
     NetworkGraphInfoResponse, OpenChannelRequest as GrpcOpenChannelRequest, OpenChannelsRequest,
     OpenChannelsResponse, PaginationRequest, PaginationResponse, Payment as PaymentMessage,
     PaymentsFilter, Peer as PeerMessage, StartNodeRequest, StartNodeResponse, StopNodeRequest,
-    StopNodeResponse, Utxo as UtxoMessage,
+    StopNodeResponse, Utxo as UtxoMessage, AddKnownPeerRequest, AddKnownPeerResponse, RemoveKnownPeerRequest, RemoveKnownPeerResponse, KnownPeer, ListKnownPeersRequest, ListKnownPeersResponse,
 };
 
 use super::sensei::{
@@ -632,3 +632,86 @@ impl TryFrom<NodeResponse> for NetworkGraphInfoResponse {
         }
     }
 }
+
+
+impl From<entity::peer::Model> for KnownPeer {
+    fn from(peer: entity::peer::Model) -> Self {
+        Self {
+            pubkey: peer.pubkey,
+            label: peer.label,
+            zero_conf: peer.zero_conf
+        }
+    }
+}
+
+impl From<ListKnownPeersRequest> for NodeRequest {
+    fn from(req: ListKnownPeersRequest) -> Self {
+        NodeRequest::ListKnownPeers {
+            pagination: req.pagination.map(|p| p.into()).unwrap_or_default(),
+        }
+    }
+}
+
+impl TryFrom<NodeResponse> for ListKnownPeersResponse {
+    type Error = String;
+
+    fn try_from(res: NodeResponse) -> Result<Self, Self::Error> {
+        match res {
+            NodeResponse::ListKnownPeers {
+                peers,
+                pagination,
+            } => {
+                let pagination: PaginationResponse = pagination.into();
+                Ok(Self {
+                    peers: peers
+                        .into_iter()
+                        .map(|peer| peer.into())
+                        .collect::<Vec<_>>(),
+                    pagination: Some(pagination),
+                })
+            }
+            _ => Err("impossible".to_string()),
+        }
+    }
+}
+
+impl From<AddKnownPeerRequest> for NodeRequest {
+    fn from(req: AddKnownPeerRequest) -> Self {
+        NodeRequest::AddKnownPeer {
+            pubkey: req.pubkey,
+            label: req.label,
+            zero_conf: req.zero_conf
+        }
+    }
+}
+
+impl TryFrom<NodeResponse> for AddKnownPeerResponse {
+    type Error = String;
+
+    fn try_from(res: NodeResponse) -> Result<Self, Self::Error> {
+        match res {
+            NodeResponse::AddKnownPeer {} => Ok(Self {}),
+            _ => Err("impossible".to_string()),
+        }
+    }
+}
+
+impl From<RemoveKnownPeerRequest> for NodeRequest {
+    fn from(req: RemoveKnownPeerRequest) -> Self {
+        NodeRequest::RemoveKnownPeer {
+            pubkey: req.pubkey
+        }
+    }
+}
+
+impl TryFrom<NodeResponse> for RemoveKnownPeerResponse {
+    type Error = String;
+
+    fn try_from(res: NodeResponse) -> Result<Self, Self::Error> {
+        match res {
+            NodeResponse::RemoveKnownPeer {} => Ok(Self {}),
+            _ => Err("impossible".to_string()),
+        }
+    }
+}
+

--- a/src/grpc/adaptor.rs
+++ b/src/grpc/adaptor.rs
@@ -8,12 +8,14 @@
 // licenses.
 
 use super::sensei::{
-    self, Channel as ChannelMessage, DeletePaymentRequest, DeletePaymentResponse,
-    Info as InfoMessage, LabelPaymentRequest, LabelPaymentResponse, NetworkGraphInfoRequest,
-    NetworkGraphInfoResponse, OpenChannelRequest as GrpcOpenChannelRequest, OpenChannelsRequest,
-    OpenChannelsResponse, PaginationRequest, PaginationResponse, Payment as PaymentMessage,
-    PaymentsFilter, Peer as PeerMessage, StartNodeRequest, StartNodeResponse, StopNodeRequest,
-    StopNodeResponse, Utxo as UtxoMessage, AddKnownPeerRequest, AddKnownPeerResponse, RemoveKnownPeerRequest, RemoveKnownPeerResponse, KnownPeer, ListKnownPeersRequest, ListKnownPeersResponse,
+    self, AddKnownPeerRequest, AddKnownPeerResponse, Channel as ChannelMessage,
+    DeletePaymentRequest, DeletePaymentResponse, Info as InfoMessage, KnownPeer,
+    LabelPaymentRequest, LabelPaymentResponse, ListKnownPeersRequest, ListKnownPeersResponse,
+    NetworkGraphInfoRequest, NetworkGraphInfoResponse,
+    OpenChannelRequest as GrpcOpenChannelRequest, OpenChannelsRequest, OpenChannelsResponse,
+    PaginationRequest, PaginationResponse, Payment as PaymentMessage, PaymentsFilter,
+    Peer as PeerMessage, RemoveKnownPeerRequest, RemoveKnownPeerResponse, StartNodeRequest,
+    StartNodeResponse, StopNodeRequest, StopNodeResponse, Utxo as UtxoMessage,
 };
 
 use super::sensei::{
@@ -633,13 +635,12 @@ impl TryFrom<NodeResponse> for NetworkGraphInfoResponse {
     }
 }
 
-
 impl From<entity::peer::Model> for KnownPeer {
     fn from(peer: entity::peer::Model) -> Self {
         Self {
             pubkey: peer.pubkey,
             label: peer.label,
-            zero_conf: peer.zero_conf
+            zero_conf: peer.zero_conf,
         }
     }
 }
@@ -657,10 +658,7 @@ impl TryFrom<NodeResponse> for ListKnownPeersResponse {
 
     fn try_from(res: NodeResponse) -> Result<Self, Self::Error> {
         match res {
-            NodeResponse::ListKnownPeers {
-                peers,
-                pagination,
-            } => {
+            NodeResponse::ListKnownPeers { peers, pagination } => {
                 let pagination: PaginationResponse = pagination.into();
                 Ok(Self {
                     peers: peers
@@ -680,7 +678,7 @@ impl From<AddKnownPeerRequest> for NodeRequest {
         NodeRequest::AddKnownPeer {
             pubkey: req.pubkey,
             label: req.label,
-            zero_conf: req.zero_conf
+            zero_conf: req.zero_conf,
         }
     }
 }
@@ -698,9 +696,7 @@ impl TryFrom<NodeResponse> for AddKnownPeerResponse {
 
 impl From<RemoveKnownPeerRequest> for NodeRequest {
     fn from(req: RemoveKnownPeerRequest) -> Self {
-        NodeRequest::RemoveKnownPeer {
-            pubkey: req.pubkey
-        }
+        NodeRequest::RemoveKnownPeer { pubkey: req.pubkey }
     }
 }
 
@@ -714,4 +710,3 @@ impl TryFrom<NodeResponse> for RemoveKnownPeerResponse {
         }
     }
 }
-

--- a/src/grpc/node.rs
+++ b/src/grpc/node.rs
@@ -23,7 +23,7 @@ use super::{
         NetworkGraphInfoRequest, NetworkGraphInfoResponse, OpenChannelsRequest,
         OpenChannelsResponse, PayInvoiceRequest, PayInvoiceResponse, SignMessageRequest,
         SignMessageResponse, StartNodeRequest, StartNodeResponse, StopNodeRequest,
-        StopNodeResponse, VerifyMessageRequest, VerifyMessageResponse,
+        StopNodeResponse, VerifyMessageRequest, VerifyMessageResponse, AddKnownPeerRequest, AddKnownPeerResponse, RemoveKnownPeerRequest, RemoveKnownPeerResponse, ListKnownPeersRequest, ListKnownPeersResponse,
     },
     utils::raw_macaroon_from_metadata,
 };
@@ -308,6 +308,36 @@ impl Node for NodeService {
         &self,
         request: tonic::Request<NetworkGraphInfoRequest>,
     ) -> Result<tonic::Response<NetworkGraphInfoResponse>, tonic::Status> {
+        self.authenticated_request(request.metadata().clone(), request.into_inner().into())
+            .await?
+            .try_into()
+            .map(Response::new)
+            .map_err(|_e| Status::unknown("unknown error"))
+    }
+    async fn list_known_peers(
+        &self,
+        request: tonic::Request<ListKnownPeersRequest>,
+    ) -> Result<tonic::Response<ListKnownPeersResponse>, tonic::Status> {
+        self.authenticated_request(request.metadata().clone(), request.into_inner().into())
+            .await?
+            .try_into()
+            .map(Response::new)
+            .map_err(|_e| Status::unknown("unknown error"))
+    }
+    async fn add_known_peer(
+        &self,
+        request: tonic::Request<AddKnownPeerRequest>,
+    ) -> Result<tonic::Response<AddKnownPeerResponse>, tonic::Status> {
+        self.authenticated_request(request.metadata().clone(), request.into_inner().into())
+            .await?
+            .try_into()
+            .map(Response::new)
+            .map_err(|_e| Status::unknown("unknown error"))
+    }
+    async fn remove_known_peer(
+        &self,
+        request: tonic::Request<RemoveKnownPeerRequest>,
+    ) -> Result<tonic::Response<RemoveKnownPeerResponse>, tonic::Status> {
         self.authenticated_request(request.metadata().clone(), request.into_inner().into())
             .await?
             .try_into()

--- a/src/grpc/node.rs
+++ b/src/grpc/node.rs
@@ -13,17 +13,18 @@ pub use super::sensei::node_server::{Node, NodeServer};
 
 use super::{
     sensei::{
-        CloseChannelRequest, CloseChannelResponse, ConnectPeerRequest, ConnectPeerResponse,
-        CreateInvoiceRequest, CreateInvoiceResponse, DecodeInvoiceRequest, DecodeInvoiceResponse,
-        DeletePaymentRequest, DeletePaymentResponse, GetBalanceRequest, GetBalanceResponse,
-        GetUnusedAddressRequest, GetUnusedAddressResponse, InfoRequest, InfoResponse,
-        KeysendRequest, KeysendResponse, LabelPaymentRequest, LabelPaymentResponse,
-        ListChannelsRequest, ListChannelsResponse, ListPaymentsRequest, ListPaymentsResponse,
-        ListPeersRequest, ListPeersResponse, ListUnspentRequest, ListUnspentResponse,
-        NetworkGraphInfoRequest, NetworkGraphInfoResponse, OpenChannelsRequest,
-        OpenChannelsResponse, PayInvoiceRequest, PayInvoiceResponse, SignMessageRequest,
+        AddKnownPeerRequest, AddKnownPeerResponse, CloseChannelRequest, CloseChannelResponse,
+        ConnectPeerRequest, ConnectPeerResponse, CreateInvoiceRequest, CreateInvoiceResponse,
+        DecodeInvoiceRequest, DecodeInvoiceResponse, DeletePaymentRequest, DeletePaymentResponse,
+        GetBalanceRequest, GetBalanceResponse, GetUnusedAddressRequest, GetUnusedAddressResponse,
+        InfoRequest, InfoResponse, KeysendRequest, KeysendResponse, LabelPaymentRequest,
+        LabelPaymentResponse, ListChannelsRequest, ListChannelsResponse, ListKnownPeersRequest,
+        ListKnownPeersResponse, ListPaymentsRequest, ListPaymentsResponse, ListPeersRequest,
+        ListPeersResponse, ListUnspentRequest, ListUnspentResponse, NetworkGraphInfoRequest,
+        NetworkGraphInfoResponse, OpenChannelsRequest, OpenChannelsResponse, PayInvoiceRequest,
+        PayInvoiceResponse, RemoveKnownPeerRequest, RemoveKnownPeerResponse, SignMessageRequest,
         SignMessageResponse, StartNodeRequest, StartNodeResponse, StopNodeRequest,
-        StopNodeResponse, VerifyMessageRequest, VerifyMessageResponse, AddKnownPeerRequest, AddKnownPeerResponse, RemoveKnownPeerRequest, RemoveKnownPeerResponse, ListKnownPeersRequest, ListKnownPeersResponse,
+        StopNodeResponse, VerifyMessageRequest, VerifyMessageResponse,
     },
     utils::raw_macaroon_from_metadata,
 };

--- a/src/http/node.rs
+++ b/src/http/node.rs
@@ -12,12 +12,14 @@ use std::sync::Arc;
 use crate::http::auth_header::AuthHeader;
 use crate::AdminService;
 use axum::extract::{Extension, Json, Query};
-use axum::routing::{get, post, delete};
+use axum::routing::{delete, get, post};
 use axum::Router;
 use http::{HeaderValue, StatusCode};
 use senseicore::services::admin::AdminRequest;
 use senseicore::services::node::{NodeRequest, NodeRequestError, NodeResponse, OpenChannelRequest};
-use senseicore::services::{ListChannelsParams, ListPaymentsParams, ListTransactionsParams, ListKnownPeersParams};
+use senseicore::services::{
+    ListChannelsParams, ListKnownPeersParams, ListPaymentsParams, ListTransactionsParams,
+};
 use senseicore::utils;
 use serde::Deserialize;
 use serde_json::Value;
@@ -195,7 +197,7 @@ impl From<VerifyMessageParams> for NodeRequest {
 pub struct AddKnownPeerParams {
     pub pubkey: String,
     pub label: String,
-    pub zero_conf: bool
+    pub zero_conf: bool,
 }
 
 impl From<AddKnownPeerParams> for NodeRequest {
@@ -203,7 +205,7 @@ impl From<AddKnownPeerParams> for NodeRequest {
         Self::AddKnownPeer {
             pubkey: params.pubkey,
             label: params.label,
-            zero_conf: params.zero_conf
+            zero_conf: params.zero_conf,
         }
     }
 }
@@ -216,7 +218,7 @@ pub struct RemoveKnownPeerParams {
 impl From<RemoveKnownPeerParams> for NodeRequest {
     fn from(params: RemoveKnownPeerParams) -> Self {
         Self::RemoveKnownPeer {
-            pubkey: params.pubkey
+            pubkey: params.pubkey,
         }
     }
 }
@@ -622,7 +624,6 @@ pub async fn network_graph_info(
     .await
 }
 
-
 pub async fn list_known_peers(
     Extension(admin_service): Extension<Arc<AdminService>>,
     Query(params): Query<ListKnownPeersParams>,
@@ -630,7 +631,7 @@ pub async fn list_known_peers(
     cookies: Cookies,
 ) -> Result<Json<NodeResponse>, StatusCode> {
     let request = NodeRequest::ListKnownPeers {
-        pagination: params.clone().into()
+        pagination: params.clone().into(),
     };
 
     handle_authenticated_request(admin_service, request, macaroon, cookies).await

--- a/web-admin/package-lock.json
+++ b/web-admin/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^1.4.2",
         "@heroicons/react": "^1.0.5",
-        "@l2-technology/sensei-client": "^0.1.17",
+        "@l2-technology/sensei-client": "^0.1.18",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.4.0",
         "@tailwindcss/typography": "^0.5.0",
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/@l2-technology/sensei-client": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.17.tgz",
-      "integrity": "sha512-vRZ52cjt4otX9/tUoiEM7b/MF8ZEcrlfZoEodHNdMyJ2g8OxTaLEjXeIXGD0nHJNPYgMONC+8jOU0//XGIgRGg=="
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.18.tgz",
+      "integrity": "sha512-lFuQf5PKK7CJ8Vy3EkjTAbUBhZvpXdZZYyUibkgQIB61wOHXfPJg5eAja40kt42uKQZSCsp176QCgLuUIz7+Gw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -25922,9 +25922,9 @@
       }
     },
     "@l2-technology/sensei-client": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.17.tgz",
-      "integrity": "sha512-vRZ52cjt4otX9/tUoiEM7b/MF8ZEcrlfZoEodHNdMyJ2g8OxTaLEjXeIXGD0nHJNPYgMONC+8jOU0//XGIgRGg=="
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.18.tgz",
+      "integrity": "sha512-lFuQf5PKK7CJ8Vy3EkjTAbUBhZvpXdZZYyUibkgQIB61wOHXfPJg5eAja40kt42uKQZSCsp176QCgLuUIz7+Gw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.2",
     "@heroicons/react": "^1.0.5",
-    "@l2-technology/sensei-client": "^0.1.17",
+    "@l2-technology/sensei-client": "^0.1.18",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/typography": "^0.5.0",

--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -16,6 +16,7 @@ import SendMoneyPage from "./payments/pages/SendMoneyPage";
 import FundPage from "./chain/pages/FundPage";
 import ReceiveMoneyPage from "./payments/pages/ReceiveMoneyPage";
 import PeersPage from "./peers/pages/PeersPage";
+import AddPeerPage from "./peers/pages/AddPeerPage";
 import NewNodePage from "./nodes/pages/NewNodePage";
 import Modal from "./components/layout/app/Modal";
 import ConfirmModal from "./components/layout/app/ConfirmModal";
@@ -58,6 +59,7 @@ function App() {
           <Route path="/admin/receive-money" element={<ReceiveMoneyPage />} />
           <Route path="/admin/send-money" element={<SendMoneyPage />} />
           <Route path="/admin/peers" element={<PeersPage />} />
+          <Route path="/admin/peers/new" element={<AddPeerPage />} />
           <Route path="/admin/nodes" element={<NodesPage />} />
           <Route path="/admin/nodes/new" element={<NewNodePage />} />
           <Route path="/admin/tokens" element={<TokensPage />} />

--- a/web-admin/src/layouts/AdminNav.tsx
+++ b/web-admin/src/layouts/AdminNav.tsx
@@ -14,6 +14,7 @@ import {
   KeyIcon,
   UserIcon,
   ChevronDownIcon,
+  UsersIcon
 } from "@heroicons/react/outline";
 import { UserCircleIcon } from "@heroicons/react/solid";
 import { useAuth } from "../contexts/auth";
@@ -61,6 +62,7 @@ const navigation = [
   { name: "Channels", href: "/admin/channels", icon: AdjustmentsIcon },
   { name: "Send Money", href: "/admin/send-money", icon: ShoppingCartIcon },
   { name: "Receive Money", href: "/admin/receive-money", icon: CashIcon },
+  { name: "Peer Directory", href: "/admin/peers", icon: UsersIcon },
   { name: "Logout", href: "/admin/logout", icon: LogoutIcon },
 ];
 

--- a/web-admin/src/peers/components/AddPeerForm.tsx
+++ b/web-admin/src/peers/components/AddPeerForm.tsx
@@ -1,0 +1,59 @@
+import { useNavigate } from "react-router";
+import { Form, Input, Select } from "../../components/form";
+import { z } from "zod";
+import addKnownPeer from "../mutations/addKnownPeer";
+
+export const AddKnownPeerInput = z.object({
+  pubkey: z.string(),
+  label: z.string(),
+  zeroConf: z.string()
+});
+
+const AddKnownPeerForm = () => {
+  let navigate = useNavigate();
+
+  let zeroConfOptions = [
+    { value: "true", text: "Accept 0-Conf" },
+    { value: "false", text: "Require Confirmations" },
+  ];
+
+  return (
+    <Form
+      submitText="Add Peer"
+      schema={AddKnownPeerInput}
+      initialValues={{
+        pubkey: "",
+        label: "",
+        zeroConf: "false",
+      }}
+      noticePosition="top"
+      layout="default"
+      onSubmit={async ({ pubkey, label, zeroConf }) => {
+        try {
+          await addKnownPeer(
+            pubkey,
+            label,
+            zeroConf === "true"
+          );
+          navigate("/admin/peers");
+        } catch (e) {
+          // TODO: handle error
+        }
+      }}
+    >
+      <Input
+        autoFocus
+        label="Pubkey"
+        name="pubkey"
+      />
+      <Input label="Label" name="label" />
+      <Select
+        label="Inbound Channel Requests"
+        name="zeroConf"
+        options={zeroConfOptions}
+      />
+    </Form>
+  );
+};
+
+export default AddKnownPeerForm;

--- a/web-admin/src/peers/components/PeersList.tsx
+++ b/web-admin/src/peers/components/PeersList.tsx
@@ -1,0 +1,229 @@
+import getKnownPeers from "../queries/getKnownPeers";
+import { useQueryClient } from "react-query";
+import {
+  TrashIcon,
+} from "@heroicons/react/outline";
+import SearchableTable from "../../components/tables/SearchableTable";
+import { useConfirm } from "../../contexts/confirm";
+import removeKnownPeer from "../mutations/removeKnownPeer";
+import addKnownPeer from "../mutations/addKnownPeer";
+import { KnownPeer } from "@l2-technology/sensei-client";
+import { useState } from "react";
+import { CheckIcon, PencilAltIcon } from "@heroicons/react/solid";
+
+const EditLabelForm = ({ knownPeer, setEditing }) => {
+  let queryClient = useQueryClient();
+  let [label, setLabel] = useState(knownPeer.label || "");
+
+  async function handleSubmit() {
+    try {
+      await addKnownPeer(knownPeer.pubkey, label, knownPeer.zeroConf);
+      setEditing(false);
+      queryClient.invalidateQueries("knownPeers");
+    } catch (e) {
+      // TODO: handle error
+    }
+  }
+
+  return (
+    <div className="flex align-middle items-center">
+      <div className="rounded-xl shadow-sm flex">
+      <input
+        type="text"
+        value={label}
+        onKeyPress={(e) => {
+          if (e.key === "Enter") {
+            handleSubmit();
+          }
+        }}
+        name="label"
+        className="input"
+        onChange={(e) => {
+          setLabel(e.target.value);
+        }}
+      />
+      </div>
+      <CheckIcon
+        onClick={handleSubmit}
+        className="inline-block w-8 h-8 text-orange cursor-pointer"
+      />
+    </div>
+  );
+};
+
+const LabelColumn = ({ knownPeer, value, className }) => {
+  let [editing, setEditing] = useState(false);
+
+  return editing ? (
+    <td
+      className={`p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum ${className}`}
+    >
+      <EditLabelForm knownPeer={knownPeer} setEditing={setEditing} />
+    </td>
+  ) : (
+    <td
+      onClick={() => setEditing(true)}
+      className={`group cursor-pointer p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum ${className}`}
+    >
+      {value}{" "}
+      <span className="inline-block group-hover:hidden">
+        &nbsp;&nbsp;&nbsp;&nbsp;
+      </span>
+      <PencilAltIcon className="w-4 h-4 cursor-pointer hidden group-hover:inline-block" />{" "}
+    </td>
+  );
+};
+
+const SimpleColumn = ({ value, className }) => {
+  return (
+    <td
+      className={`p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum ${className}`}
+    >
+      {value}
+    </td>
+  );
+};
+
+const ZeroConfColumn = ({ knownPeer, value, className }) => {
+  let queryClient = useQueryClient();
+  const toggleZeroConf = async () => {
+    await addKnownPeer(knownPeer.pubkey, knownPeer.label, !knownPeer.zeroConf)
+    queryClient.invalidateQueries("knownPeers")
+  }
+
+  return (
+    <td
+      onClick={toggleZeroConf}
+      className={`p-3 md:px-6 md:py-4 select-none whitespace-nowrap text-sm leading-5 font-medium text-light-plum cursor-pointer ${className}`}
+    >
+      {value && (<div className="">Accept 0-Conf</div>)}
+      {!value && (<div className="">Requires Confirmations</div>)}
+    </td>
+  );
+};
+
+const ActionsColumn = ({ knownPeer, className }) => {
+  const { showConfirm } = useConfirm();
+  const queryClient = useQueryClient();
+
+  let removePeerMessage = "You cannot undo this action without manually adding the peer again."
+  
+  if(knownPeer.zeroConf) {
+    removePeerMessage += " You will no longer automatically accept 0-conf channels from this peer."
+  }
+
+  const removeKnownPeerClicked = () => {
+    showConfirm({
+      title: "Are you sure you want to remove this known peer?",
+      description: removePeerMessage,
+      ctaText: "Yes, remove them",
+      callback: async () => {
+        await removeKnownPeer(knownPeer.pubkey);
+        queryClient.invalidateQueries("knownPeers");
+      },
+    });
+  };
+  return (
+    <td
+      className={`p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum ${className}`}
+    >
+      <TrashIcon
+        className="inline-block h-6 cursor-pointer"
+        onClick={removeKnownPeerClicked}
+      />
+    </td>
+  );
+};
+
+const KnownPeerRow = ({ result, extraClass, attributes }) => {
+  let columnKeyComponentMap = {
+    label: LabelColumn,
+    zeroConf: ZeroConfColumn,
+    actions: ActionsColumn,
+  };
+
+  return (
+    <tr className={`${extraClass}`}>
+      {attributes.map(({ key, className }) => {
+        let value = result[key];
+        let ColumnComponent = columnKeyComponentMap[key]
+          ? columnKeyComponentMap[key]
+          : SimpleColumn;
+        return (
+          <ColumnComponent
+            key={key}
+            knownPeer={result}
+            value={value}
+            className={className}
+          />
+        );
+      })}
+    </tr>
+  );
+};
+
+const KnownPeersList = () => {
+  const emptyTableHeadline = "No peers found";
+  const emptyTableSubtext = "Try changing the search term";
+  const searchBarPlaceholder = "Search";
+
+  const attributes = [
+    {
+      key: "label",
+      label: "Label",
+    },
+    {
+      key: "pubkey",
+      label: "Pubkey",
+    },
+    {
+      key: "zeroConf",
+      label: "Inbound Channel Requests",
+    },
+    {
+      key: "actions",
+      label: "Actions",
+    },
+  ];
+
+  const transformResults = (knownPeers: KnownPeer[]) => {
+    return knownPeers.map((knownPeer) => {
+      return {
+        ...knownPeer,
+        id: knownPeer.pubkey,
+        actions: "",
+      };
+    });
+  };
+
+  const queryFunction = async ({ queryKey }) => {
+    const [_key, { page, searchTerm, take }] = queryKey;
+    const { peers, pagination } = await getKnownPeers({
+      page,
+      searchTerm,
+      take,
+    });
+    return {
+      results: transformResults(peers),
+      hasMore: pagination.hasMore,
+      total: pagination.total,
+    };
+  };
+
+  return (
+    <SearchableTable
+      attributes={attributes}
+      queryKey="knownPeers"
+      queryFunction={queryFunction}
+      emptyTableHeadline={emptyTableHeadline}
+      emptyTableSubtext={emptyTableSubtext}
+      searchBarPlaceholder={searchBarPlaceholder}
+      hasHeader
+      itemsPerPage={5}
+      RowComponent={KnownPeerRow}
+      striped={true}
+    />
+  );
+};
+
+export default KnownPeersList;

--- a/web-admin/src/peers/mutations/addKnownPeer.ts
+++ b/web-admin/src/peers/mutations/addKnownPeer.ts
@@ -1,0 +1,11 @@
+import sensei from "../../utils/sensei";
+
+const addKnownPeer = async (
+  pubkey: string,
+  label: string,
+  zeroConf: boolean
+) => {
+  return await sensei.addKnownPeer(pubkey, label, zeroConf)
+};
+
+export default addKnownPeer;

--- a/web-admin/src/peers/mutations/removeKnownPeer.ts
+++ b/web-admin/src/peers/mutations/removeKnownPeer.ts
@@ -1,0 +1,9 @@
+import sensei from "../../utils/sensei";
+
+const removeKnownPeer = async (
+  pubkey: string
+) => {
+  return await sensei.removeKnownPeer(pubkey)
+};
+
+export default removeKnownPeer;

--- a/web-admin/src/peers/pages/AddPeerPage.tsx
+++ b/web-admin/src/peers/pages/AddPeerPage.tsx
@@ -1,0 +1,31 @@
+import AddPeerForm from "../components/AddPeerForm";
+import { Link } from "react-router-dom";
+
+const AddPeerPage = () => {
+  return (
+    <div className="py-12">
+      <div className="">
+        <div className="pb-5 border-b border-gray-400 sm:flex sm:items-center sm:justify-between">
+          <h3 className="text-2xl leading-6 font-medium text-light-plum">
+            Add Peer
+          </h3>
+
+          <div className="mt-3 sm:mt-0 sm:ml-4">
+            <Link to="/admin/peers" className="btn-ghost">
+              Cancel
+            </Link>
+          </div>
+        </div>
+      </div>
+      <div className="">
+        <div className="py-4">
+          <div className="bg-plum-100 text-light-plum shadow p-4 rounded-xl">
+            <AddPeerForm />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AddPeerPage;

--- a/web-admin/src/peers/pages/PeersPage.tsx
+++ b/web-admin/src/peers/pages/PeersPage.tsx
@@ -1,12 +1,24 @@
+import { Link } from "react-router-dom";
+import PeersList from "../components/PeersList";
+
 const PeersPage = () => {
   return (
-    <div className="py-6">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h1 className="text-2xl font-semibold text-gray-900">Peers</h1>
+    <div className="py-12">
+      <div className="">
+        <div className="pb-5 border-b border-plum-200 sm:flex sm:items-center sm:justify-between">
+          <h3 className="text-2xl leading-6 font-medium text-light-plum">
+            Peer Directory
+          </h3>
+          <div className="mt-3 sm:mt-0 sm:ml-4">
+            <Link to="/admin/peers/new" className="btn-orange">
+              Add Peer
+            </Link>
+          </div>
+        </div>
       </div>
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">
-        <div className="py-4">
-          <div className="border-4 border-dashed border-gray-400 rounded-lg h-96" />
+      <div className="py-4 relative">
+        <div className="bg-gray-accent2 -mx-4 sm:mx-0 sm:rounded-xl overflow-x-auto">
+          <PeersList />
         </div>
       </div>
     </div>

--- a/web-admin/src/peers/queries/getKnownPeers.ts
+++ b/web-admin/src/peers/queries/getKnownPeers.ts
@@ -1,0 +1,7 @@
+import sensei from "../../utils/sensei";
+
+const getPeers = async ({ page, take, searchTerm }) => {
+  return await sensei.getKnownPeers({page, take, searchTerm})
+};
+
+export default getPeers;


### PR DESCRIPTION
This enables 0-conf channels by default for all outbound channels. 0-conf inbound channels are disabled by default.  This adds a "Peer Directory" where you can enable 0-conf channels for peers by pubkey.