### PR TITLE
ui/ux cleanup

### DIFF
--- a/senseicore/tests/smoke_test.rs
+++ b/senseicore/tests/smoke_test.rs
@@ -457,7 +457,7 @@ mod test {
             channels.len() > 0 && channels[0].is_usable
         };
 
-        assert!(wait_until(Box::new(has_usable_channel), 15000, 250).await);
+        assert!(wait_until(Box::new(has_usable_channel), 30000, 250).await);
 
         from.list_channels(PaginationRequest {
             page: 0,

--- a/web-admin/package-lock.json
+++ b/web-admin/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^1.4.2",
         "@heroicons/react": "^1.0.5",
-        "@l2-technology/sensei-client": "^0.1.18",
+        "@l2-technology/sensei-client": "^0.1.20",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.4.0",
         "@tailwindcss/typography": "^0.5.0",
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/@l2-technology/sensei-client": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.18.tgz",
-      "integrity": "sha512-lFuQf5PKK7CJ8Vy3EkjTAbUBhZvpXdZZYyUibkgQIB61wOHXfPJg5eAja40kt42uKQZSCsp176QCgLuUIz7+Gw=="
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.20.tgz",
+      "integrity": "sha512-1zipy1YphCpa6gNQis/ZDrEaHrr+UML+ifCzeU7aZhSQf0UdViqlXD+aOI4+BQMAlBfb8j68L/x808pEN1khEQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -25922,9 +25922,9 @@
       }
     },
     "@l2-technology/sensei-client": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.18.tgz",
-      "integrity": "sha512-lFuQf5PKK7CJ8Vy3EkjTAbUBhZvpXdZZYyUibkgQIB61wOHXfPJg5eAja40kt42uKQZSCsp176QCgLuUIz7+Gw=="
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.20.tgz",
+      "integrity": "sha512-1zipy1YphCpa6gNQis/ZDrEaHrr+UML+ifCzeU7aZhSQf0UdViqlXD+aOI4+BQMAlBfb8j68L/x808pEN1khEQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.2",
     "@heroicons/react": "^1.0.5",
-    "@l2-technology/sensei-client": "^0.1.18",
+    "@l2-technology/sensei-client": "^0.1.20",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/typography": "^0.5.0",

--- a/web-admin/src/chain/components/UnusedAddress.tsx
+++ b/web-admin/src/chain/components/UnusedAddress.tsx
@@ -1,8 +1,21 @@
 import getUnusedAddress from "../queries/getUnusedAddress";
 import { useQuery } from "react-query";
 import QRCode from "react-qr-code";
+import copy from "copy-to-clipboard";
+import { useNotification } from "src/contexts/notification";
+import { CheckIcon, ClipboardCopyIcon } from "@heroicons/react/outline";
+
+const CopiedAddressNotification = () => {
+  return (
+    <div className="">
+      <p className="text-sm font-medium text-gray-50">Address Copied to Clipboard</p>
+    </div>
+  );
+};
 
 const UnusedAddress = () => {
+  const { showNotification, hideNotification } = useNotification()
+  
   const { isLoading, isError, data } = useQuery(
     "unused_address",
     getUnusedAddress
@@ -15,21 +28,26 @@ const UnusedAddress = () => {
   let { address } = data;
 
   return (
-    <div className="">
+    <div>
       <div
-        style={{ width: "305px" }}
-        className="bg-white shadow overflow-hidden sm:rounded-lg p-6 mx-auto"
+        style={{ width: "145px" }}
+        className="bg-white shadow overflow-hidden sm:rounded-lg p-2 cursor-pointer hover:scale-110 transition-all ease-in-out duration-200"
+        onClick={() => {
+          copy(address)
+          showNotification({
+            component: <CopiedAddressNotification/>,
+            iconComponent: <CheckIcon className="h-6 w-6 text-orange" />
+          })
+          setTimeout(hideNotification, 1000)
+        }}
       >
         <QRCode
           value={address}
-          size={256}
+          size={128}
           bgColor={"#FFFFFF"}
           fgColor={"#000000"}
           level={"L"}
         />
-      </div>
-      <div className="text-center text-lg md:text-xl lg:text-2xl m-8">
-        {address}
       </div>
     </div>
   );

--- a/web-admin/src/chain/pages/ChainPage.tsx
+++ b/web-admin/src/chain/pages/ChainPage.tsx
@@ -1,8 +1,19 @@
 import OnChainBalance from "../components/OnChainBalance";
 import TransactionsList from "src/transactions/components/TransactionsList";
+import UnusedAddress from "../components/UnusedAddress";
 const ChainPage = () => {
   return (
     <div className="py-6">
+      <div className="">
+        <h1 className="text-2xl font-semibold text-plum-light">Fund Node</h1>
+      </div>
+      <div className="">
+        <div className="py-4">
+          <div className="mb-8">
+            <UnusedAddress />
+          </div>
+        </div>
+      </div>
       <div className="">
         <h1 className="text-2xl font-semibold text-plum-light">Balance</h1>
       </div>

--- a/web-admin/src/channels/components/ChannelsList.tsx
+++ b/web-admin/src/channels/components/ChannelsList.tsx
@@ -230,6 +230,15 @@ const ChannelsList = () => {
     };
   };
 
+  // TODO: when channels are stored in db and can be in error state
+  //       need to make sure we aren't polling failed/closed channels
+  const refetchInterval = (data, query) => {
+    const hasPendingChannel = data?.results.find(channel => {
+      return channel.status !== "ready"
+    })
+    return hasPendingChannel ? 1000 : false
+  }
+
   return (
     <SearchableTable
       attributes={attributes}
@@ -242,6 +251,7 @@ const ChannelsList = () => {
       itemsPerPage={5}
       RowComponent={ChannelRow}
       striped={true}
+      refetchInterval={refetchInterval}
     />
   );
 };

--- a/web-admin/src/components/form/TextArea.tsx
+++ b/web-admin/src/components/form/TextArea.tsx
@@ -31,6 +31,8 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
       meta: { dirty, error, submitFailed, submitError, submitting },
     } = useField(name);
 
+    let myOnChange = props.onChange ? (e) => {props.onChange(e); input.onChange(e) } : input.onChange;
+    
     const hasError = (dirty || submitFailed) && (error || submitError);
 
     return (
@@ -47,6 +49,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             {...input}
             disabled={submitting}
             {...props}
+            onChange={myOnChange}
             ref={ref}
             className={`form-input block border rounded-xl w-full bg-plum text-light-plum transition duration-150 ease-in-out sm:text-sm sm:leading-5 flex-1 ${
               hasError

--- a/web-admin/src/components/layout/app/NotificationContainer.tsx
+++ b/web-admin/src/components/layout/app/NotificationContainer.tsx
@@ -1,12 +1,10 @@
 import { Transition } from "@headlessui/react";
 import { useNotification } from "../../../contexts/notification";
 import { Fragment } from "react";
-import { InboxIcon } from "@heroicons/react/outline";
 import { XIcon } from "@heroicons/react/outline";
 
 const NotificationContainer = () => {
-  const { hideNotification, component, isOpen } = useNotification();
-
+  const { hideNotification, component, isOpen, iconComponent } = useNotification();
   return (
     <>
       {/* Global notification live region, render this permanently at the end of the document */}
@@ -29,10 +27,7 @@ const NotificationContainer = () => {
               <div className="p-4">
                 <div className="flex items-start">
                   <div className="flex-shrink-0">
-                    <InboxIcon
-                      className="h-6 w-6 text-light-plum"
-                      aria-hidden="true"
-                    />
+                    {iconComponent}
                   </div>
                   <div className="ml-3 w-0 flex-1 pt-0.5">{component}</div>
                   <div className="ml-4 flex-shrink-0 flex">

--- a/web-admin/src/components/tables/EditableLabelColumn.tsx
+++ b/web-admin/src/components/tables/EditableLabelColumn.tsx
@@ -1,0 +1,82 @@
+import { CheckIcon, PencilAltIcon } from "@heroicons/react/outline";
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "react-query";
+
+const EditLabelForm = ({ currentLabel, queryKey, updateLabel, setEditing, editing }) => {
+  const labelInputEl = useRef(null);
+  let queryClient = useQueryClient();
+  let [label, setLabel] = useState(currentLabel || "");
+
+  useEffect(() => {
+    if(editing && labelInputEl.current) {
+      labelInputEl.current.focus()
+    }
+  }, [editing])
+
+  async function handleSubmit() {
+    try {
+      if(label !== currentLabel) {
+        await updateLabel(label)
+      }
+      setEditing(false);
+      queryClient.invalidateQueries(queryKey);
+    } catch (e) {
+      // TODO: handle error
+    }
+  }
+
+  return (
+    <div className="flex align-middle items-center">
+      <input
+        type="text"
+        ref={labelInputEl}
+        value={label}
+        onKeyPress={(e) => {
+          if (e.key === "Enter") {
+            handleSubmit();
+          }
+        }}
+        name="label"
+        className="input"
+        onChange={(e) => {
+          setLabel(e.target.value);
+        }}
+      />
+      <CheckIcon
+        onClick={handleSubmit}
+        className="inline-block w-8 h-8 text-green-600 cursor-pointer"
+      />
+    </div>
+  );
+};
+
+const EditableLabelColumn = ({ updateLabel, queryKey, label }) => {
+  let [editing, setEditing] = useState(false);
+
+  return editing ? (
+    <td
+      className={`p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum`}
+    >
+      <EditLabelForm 
+        currentLabel={label} 
+        queryKey={queryKey} 
+        updateLabel={updateLabel} 
+        editing={editing} 
+        setEditing={setEditing} 
+      />
+    </td>
+  ) : (
+    <td
+      onClick={() => setEditing(true)}
+      className={`group cursor-pointer p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum`}
+    >
+      {label}{" "}
+      <span className="inline-block group-hover:hidden">
+        &nbsp;&nbsp;&nbsp;&nbsp;
+      </span>
+      <PencilAltIcon className="w-4 h-4 cursor-pointer hidden group-hover:inline-block" />{" "}
+    </td>
+  );
+}
+
+export default EditableLabelColumn

--- a/web-admin/src/components/tables/SearchableTable.tsx
+++ b/web-admin/src/components/tables/SearchableTable.tsx
@@ -216,6 +216,7 @@ interface SearchableTableProps<T> {
   searchBarTitle?: string | null;
   searchBarPlaceholder: string;
   RowComponent?: ReactNode;
+  refetchInterval?: number | false | ((data: any, query: any) => number | false);
 }
 
 const SimpleSearchableTable = <T extends object>({
@@ -231,6 +232,7 @@ const SimpleSearchableTable = <T extends object>({
   searchBarTitle = null,
   searchBarPlaceholder,
   RowComponent = SimpleRow,
+  refetchInterval = false
 }: SearchableTableProps<T>) => {
   const [page, setPage] = useState(0);
   const [searchTerm, setSearchTerm] = useState("");
@@ -245,7 +247,10 @@ const SimpleSearchableTable = <T extends object>({
   const { data, isLoading, isError } = useQuery(
     [queryKey, { page, searchTerm, skip, take }],
     queryFunction,
-    { keepPreviousData: true }
+    { 
+      keepPreviousData: true,
+      refetchInterval
+    }
   );
 
   if (isLoading) {

--- a/web-admin/src/contexts/auth.tsx
+++ b/web-admin/src/contexts/auth.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import sensei from "../utils/sensei";
 
 interface NodeStatus {
+  version: string;
   created: boolean;
   running: boolean;
   authenticated: boolean;

--- a/web-admin/src/contexts/notification.tsx
+++ b/web-admin/src/contexts/notification.tsx
@@ -1,3 +1,4 @@
+import { InboxIcon } from "@heroicons/react/outline";
 import React, {
   createContext,
   ReactNode,
@@ -9,11 +10,13 @@ import React, {
 interface NotificationContextOptions {
   isOpen: boolean;
   component: ReactNode | null;
+  iconComponent: ReactNode | null;
 }
 
 const defaultOptions: NotificationContextOptions = {
   isOpen: false,
   component: null,
+  iconComponent: null
 };
 
 const NotificationContext = createContext(null);
@@ -41,7 +44,7 @@ function useNotification() {
 
   const hideNotification = () => {
     setNotification({
-      ...notification,
+      ...defaultOptions,
       isOpen: false,
     });
   };

--- a/web-admin/src/layouts/AdminNav.tsx
+++ b/web-admin/src/layouts/AdminNav.tsx
@@ -57,7 +57,6 @@ const adminNav = [
 ];
 
 const navigation = [
-  { name: "Fund Node", href: "/admin/fund", icon: QrcodeIcon },
   { name: "Chain", href: "/admin/chain", icon: LinkIcon },
   { name: "Channels", href: "/admin/channels", icon: AdjustmentsIcon },
   { name: "Send Money", href: "/admin/send-money", icon: ShoppingCartIcon },

--- a/web-admin/src/layouts/AdminNav.tsx
+++ b/web-admin/src/layouts/AdminNav.tsx
@@ -149,7 +149,7 @@ export const AdminSidebar = ({ setSidebarOpen }: SidebarProps) => {
                   isActive
                     ? "bg-orange text-white hover:bg-orange-hover"
                     : "text-gray-300 hover:bg-white hover:bg-opacity-5 hover:text-white"
-                } group flex items-center rounded-xl px-3 py-2  text-sm font-medium last:!mt-auto`;
+                } group flex items-center rounded-xl px-3 py-2  text-sm font-medium`;
               }}
             >
               {({ isActive }) => {
@@ -170,6 +170,7 @@ export const AdminSidebar = ({ setSidebarOpen }: SidebarProps) => {
             </NavLink>
           ))}
         </nav>
+        <div className="text-gray-400 pt-3 text-center">Sensei v{auth.status.version}</div>
       </div>
     </div>
   );

--- a/web-admin/src/payments/components/CreateInvoiceForm.tsx
+++ b/web-admin/src/payments/components/CreateInvoiceForm.tsx
@@ -6,7 +6,7 @@ import { useNotification } from "../../contexts/notification";
 import copy from "copy-to-clipboard";
 
 export const CreateInvoiceInput = z.object({
-  amountMillisats: z.string(),
+  amountSats: z.string(),
   description: z.string(),
 });
 
@@ -53,11 +53,11 @@ const CreateInvoiceForm = () => {
       noticePosition="top"
       layout="default"
       resetAfterSuccess={true}
-      initialValues={{ description: "", amountMillisats: "" }}
-      onSubmit={async ({ description, amountMillisats }) => {
+      initialValues={{ description: "", amountSats: "" }}
+      onSubmit={async ({ description, amountSats }) => {
         try {
           const { invoice } = await createInvoice(
-            parseInt(amountMillisats, 10),
+            parseInt(amountSats, 10) * 1000,
             description
           );
 
@@ -74,8 +74,8 @@ const CreateInvoiceForm = () => {
       <Input autoFocus label="Description" name="description" />
       <Input
         min={1}
-        label="Amount Millisats"
-        name="amountMillisats"
+        label="Amount Sats"
+        name="amountSats"
         type="number"
       />
     </Form>

--- a/web-admin/src/payments/components/CreateInvoiceForm.tsx
+++ b/web-admin/src/payments/components/CreateInvoiceForm.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "react-query";
 import { z } from "zod";
 import { useNotification } from "../../contexts/notification";
 import copy from "copy-to-clipboard";
+import { InboxIcon } from "@heroicons/react/outline";
 
 export const CreateInvoiceInput = z.object({
   amountSats: z.string(),
@@ -65,6 +66,7 @@ const CreateInvoiceForm = () => {
 
           showNotification({
             component: <NewInvoiceNotification invoice={invoice} />,
+            iconComponent: <InboxIcon className="h-6 w-6 text-light-plum" aria-hidden="true"/>
           });
         } catch (e) {
           // TODO: handle error

--- a/web-admin/src/payments/components/PayInvoiceForm.tsx
+++ b/web-admin/src/payments/components/PayInvoiceForm.tsx
@@ -2,12 +2,14 @@ import { useNavigate } from "react-router";
 import payInvoice from "../mutations/payInvoice";
 import { Form, TextArea } from "../../components/form";
 import { z } from "zod";
+import { useQueryClient } from "react-query";
 
 export const CreateInvoiceInput = z.object({
   invoice: z.string(),
 });
 
 const PayInvoiceForm = () => {
+  const queryClient = useQueryClient();
   let navigate = useNavigate();
 
   return (
@@ -16,10 +18,12 @@ const PayInvoiceForm = () => {
       schema={CreateInvoiceInput}
       noticePosition="top"
       layout="default"
+      resetAfterSuccess={true}
       onSubmit={async ({ invoice }) => {
         try {
           await payInvoice(invoice);
-          navigate("/admin/payments");
+          queryClient.invalidateQueries("payments")
+          
         } catch (e) {
           // TODO: handle error
         }

--- a/web-admin/src/payments/components/PaymentsList.tsx
+++ b/web-admin/src/payments/components/PaymentsList.tsx
@@ -225,6 +225,13 @@ const PaymentsList = ({ origin = "", status = "" }) => {
     });
   };
 
+  const refetchInterval = (data, query) => {
+    const hasPendingPayment = data?.results.find(payment => {
+      return payment.status === "pending"
+    })
+    return hasPendingPayment ? 1000 : false
+  }
+
   const queryFunction = async ({ queryKey }) => {
     const [_key, { page, searchTerm, take }] = queryKey;
     const { payments, pagination } = await getPayments({
@@ -253,6 +260,7 @@ const PaymentsList = ({ origin = "", status = "" }) => {
       hasHeader
       itemsPerPage={5}
       RowComponent={PaymentRow}
+      refetchInterval={refetchInterval}
     />
   );
 };

--- a/web-admin/src/payments/components/PaymentsList.tsx
+++ b/web-admin/src/payments/components/PaymentsList.tsx
@@ -2,76 +2,26 @@ import { truncateMiddle } from "../../utils/capitalize";
 import SearchableTable from "../../components/tables/SearchableTable";
 import getPayments from "../queries/getPayments";
 import labelPayment from "../mutations/labelPayment";
-import { useQueryClient } from "react-query";
 import copy from "copy-to-clipboard";
 import { Payment } from "@l2-technology/sensei-client";
-
 import { useState } from "react";
 import {
-  CheckIcon,
-  PencilAltIcon,
   ClipboardCopyIcon,
 } from "@heroicons/react/outline";
+import EditableLabelColumn from "src/components/tables/EditableLabelColumn";
 
-const EditLabelForm = ({ payment, setEditing }) => {
-  let queryClient = useQueryClient();
-  let [label, setLabel] = useState(payment.label || "");
-
-  async function handleSubmit() {
-    try {
-      await labelPayment(label, payment.paymentHash);
-      setEditing(false);
-      queryClient.invalidateQueries("payments");
-    } catch (e) {
-      // TODO: handle error
-    }
+const LabelColumn = ({ payment, value }) => {
+  
+  const updateLabel = async (newLabel) => {
+    await labelPayment(newLabel, payment.paymentHash);
   }
 
-  return (
-    <div className="flex align-middle items-center">
-      <input
-        type="text"
-        value={label}
-        onKeyPress={(e) => {
-          if (e.key === "Enter") {
-            handleSubmit();
-          }
-        }}
-        name="label"
-        className="h-6 text-sm w-32 border rounded"
-        onChange={(e) => {
-          setLabel(e.target.value);
-        }}
-      />
-      <CheckIcon
-        onClick={handleSubmit}
-        className="inline-block w-5 h-5 text-green-600 cursor-pointer"
-      />
-    </div>
-  );
-};
-
-const LabelColumn = ({ payment, value, className }) => {
-  let [editing, setEditing] = useState(false);
-
-  return editing ? (
-    <td
-      className={`p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum ${className}`}
-    >
-      <EditLabelForm payment={payment} setEditing={setEditing} />
-    </td>
-  ) : (
-    <td
-      onClick={() => setEditing(true)}
-      className={`group cursor-pointer p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum ${className}`}
-    >
-      {value}{" "}
-      <span className="inline-block group-hover:hidden">
-        &nbsp;&nbsp;&nbsp;&nbsp;
-      </span>
-      <PencilAltIcon className="w-4 h-4 cursor-pointer hidden group-hover:inline-block" />{" "}
-    </td>
-  );
+  return <EditableLabelColumn 
+    label={value} 
+    updateLabel={updateLabel} 
+    queryKey={"payments"} 
+  />
+  
 };
 
 const AmountColumn = ({ value, className }) => {

--- a/web-admin/src/payments/mutations/decodeInvoice.ts
+++ b/web-admin/src/payments/mutations/decodeInvoice.ts
@@ -1,0 +1,7 @@
+import sensei from "../../utils/sensei";
+
+const decodeInvoice = async (invoice: string) => {
+  return await sensei.decodeInvoice(invoice);
+};
+
+export default decodeInvoice;

--- a/web-admin/src/peers/components/PeersList.tsx
+++ b/web-admin/src/peers/components/PeersList.tsx
@@ -8,70 +8,20 @@ import { useConfirm } from "../../contexts/confirm";
 import removeKnownPeer from "../mutations/removeKnownPeer";
 import addKnownPeer from "../mutations/addKnownPeer";
 import { KnownPeer } from "@l2-technology/sensei-client";
-import { useState } from "react";
-import { CheckIcon, PencilAltIcon } from "@heroicons/react/solid";
+import EditableLabelColumn from "src/components/tables/EditableLabelColumn";
 
-const EditLabelForm = ({ knownPeer, setEditing }) => {
-  let queryClient = useQueryClient();
-  let [label, setLabel] = useState(knownPeer.label || "");
-
-  async function handleSubmit() {
-    try {
-      await addKnownPeer(knownPeer.pubkey, label, knownPeer.zeroConf);
-      setEditing(false);
-      queryClient.invalidateQueries("knownPeers");
-    } catch (e) {
-      // TODO: handle error
-    }
+const LabelColumn = ({ knownPeer, value }) => {
+  
+  const updateLabel = async (newLabel) => {
+    await addKnownPeer(knownPeer.pubkey, newLabel, knownPeer.zeroConf);
   }
 
-  return (
-    <div className="flex align-middle items-center">
-      <div className="rounded-xl shadow-sm flex">
-      <input
-        type="text"
-        value={label}
-        onKeyPress={(e) => {
-          if (e.key === "Enter") {
-            handleSubmit();
-          }
-        }}
-        name="label"
-        className="input"
-        onChange={(e) => {
-          setLabel(e.target.value);
-        }}
-      />
-      </div>
-      <CheckIcon
-        onClick={handleSubmit}
-        className="inline-block w-8 h-8 text-orange cursor-pointer"
-      />
-    </div>
-  );
-};
-
-const LabelColumn = ({ knownPeer, value, className }) => {
-  let [editing, setEditing] = useState(false);
-
-  return editing ? (
-    <td
-      className={`p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum ${className}`}
-    >
-      <EditLabelForm knownPeer={knownPeer} setEditing={setEditing} />
-    </td>
-  ) : (
-    <td
-      onClick={() => setEditing(true)}
-      className={`group cursor-pointer p-3 md:px-6 md:py-4  whitespace-nowrap text-sm leading-5 font-medium text-light-plum ${className}`}
-    >
-      {value}{" "}
-      <span className="inline-block group-hover:hidden">
-        &nbsp;&nbsp;&nbsp;&nbsp;
-      </span>
-      <PencilAltIcon className="w-4 h-4 cursor-pointer hidden group-hover:inline-block" />{" "}
-    </td>
-  );
+  return <EditableLabelColumn 
+    label={value} 
+    updateLabel={updateLabel} 
+    queryKey={"knownPeers"} 
+  />
+  
 };
 
 const SimpleColumn = ({ value, className }) => {


### PR DESCRIPTION
Fix several ui/ux issues that have been bugging me as we prepare for an Umbrel release.

- Switched invoice creation to use sats instead of millisats.
- Fix incorrect navigation after paying an invoice.
- Tables now poll for updated data whenever they contain Pending data.  This means your payments and channels will automatically update when they are completed and opened respectively.
- Fixed the UI around editable label columns and extracted a shared component.
- Decode the invoice and show a summary before paying.  Previously you couldn't know if the invoice you pasted was correct or what it was about to pay.
- Moved the fund node page to the chain page with some clean-up there.  Added click to copy QR code w/ toast notification.
- Surfaced the sensei version number in the sidebar