### PR TITLE
feat: add support for custom expiry

### DIFF
--- a/proto/sensei.proto
+++ b/proto/sensei.proto
@@ -292,6 +292,7 @@ message KeysendResponse {}
 message CreateInvoiceRequest {
     uint64 amt_msat = 1;
     string description = 2;
+    optional uint32 expiry = 3;
 }
 message CreateInvoiceResponse {
     string invoice = 1;

--- a/senseicore/src/services/node.rs
+++ b/senseicore/src/services/node.rs
@@ -203,6 +203,7 @@ pub enum NodeRequest {
     GetInvoice {
         amt_msat: u64,
         description: String,
+        expiry: Option<u32>,
     },
     LabelPayment {
         label: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -311,6 +311,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let request = tonic::Request::new(CreateInvoiceRequest {
                                 amt_msat,
                                 description: String::from(""),
+                                expiry: Some(3600),
                             });
                             let response = client.create_invoice(request).await?;
                             println!("{:?}", response.into_inner());

--- a/src/grpc/adaptor.rs
+++ b/src/grpc/adaptor.rs
@@ -352,6 +352,7 @@ impl From<CreateInvoiceRequest> for NodeRequest {
         NodeRequest::GetInvoice {
             amt_msat: req.amt_msat,
             description: req.description,
+            expiry: req.expiry,
         }
     }
 }

--- a/src/http/node.rs
+++ b/src/http/node.rs
@@ -31,6 +31,7 @@ use super::utils::get_macaroon_hex_str_from_cookies_or_header;
 pub struct GetInvoiceParams {
     pub amt_msat: u64,
     pub description: String,
+    pub expiry: Option<u32>,
 }
 
 impl From<GetInvoiceParams> for NodeRequest {
@@ -38,6 +39,7 @@ impl From<GetInvoiceParams> for NodeRequest {
         Self::GetInvoice {
             amt_msat: params.amt_msat,
             description: params.description,
+            expiry: params.expiry,
         }
     }
 }


### PR DESCRIPTION
A quick PR adding support for custom invoice expiry delta in seconds. By default, it was set to 3600 (one hour). It is now possible to add an optional parameter to change this value.

The API and internal functions are the only scopes of this PR, a follow-up PR would be needed to add CLI and Web support.

@johncantrell97 Do I need to add an expiry column to the [`Payment`](https://github.com/louneskmt/sensei/blob/df4de8c11f8fbc5856dc537c97ac4b730261fcdd/entity/src/payment.rs) Model?