### PR TITLE
improve channel open error handling

### DIFF
--- a/proto/sensei.proto
+++ b/proto/sensei.proto
@@ -217,7 +217,7 @@ message OpenChannelRequest {
 message OpenChannelResult {
     bool error = 1;
     optional string error_message = 2;
-    optional string temp_channel_id = 3;
+    optional string channel_id = 3;
 }
 
 message OpenChannelsRequest {

--- a/senseicore/src/error.rs
+++ b/senseicore/src/error.rs
@@ -36,6 +36,7 @@ pub enum Error {
     AdminNodeNotStarted,
     AdminNodeNotCreated,
     FundingGenerationNeverHappened,
+    ChannelOpenRejected(String),
     NodeBeingStartedAlready,
 }
 
@@ -66,6 +67,9 @@ impl Display for Error {
             Error::NodeBeingStartedAlready => String::from("node already being started"),
             Error::FundingGenerationNeverHappened => {
                 String::from("funding generation for request never happened")
+            }
+            Error::ChannelOpenRejected(reason) => {
+                format!("Channel open rejected by peer: {:?}", reason)
             }
         };
         write!(f, "{}", str)

--- a/senseicore/src/events.rs
+++ b/senseicore/src/events.rs
@@ -15,4 +15,10 @@ pub enum SenseiEvent {
         user_channel_id: u64,
         counterparty_node_id: PublicKey,
     },
+    ChannelClosed {
+        node_id: String,
+        channel_id: [u8; 32],
+        user_channel_id: u64,
+        reason: String,
+    },
 }

--- a/senseicore/src/services/node.rs
+++ b/senseicore/src/services/node.rs
@@ -169,7 +169,7 @@ impl From<&OpenChannelRequest> for UserConfig {
 pub struct OpenChannelResult {
     pub error: bool,
     pub error_message: Option<String>,
-    pub temp_channel_id: Option<String>,
+    pub channel_id: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/src/grpc/adaptor.rs
+++ b/src/grpc/adaptor.rs
@@ -278,7 +278,7 @@ impl TryFrom<NodeResponse> for OpenChannelsResponse {
                     .map(|result| sensei::OpenChannelResult {
                         error: result.error,
                         error_message: result.error_message,
-                        temp_channel_id: result.temp_channel_id,
+                        channel_id: result.channel_id,
                     })
                     .collect::<Vec<_>>(),
             }),

--- a/src/http/utils.rs
+++ b/src/http/utils.rs
@@ -1,3 +1,4 @@
+use axum::response::{IntoResponse, Response};
 use headers::HeaderValue;
 use http::StatusCode;
 use tower_cookies::Cookies;
@@ -5,13 +6,13 @@ use tower_cookies::Cookies;
 pub fn get_macaroon_hex_str_from_cookies_or_header(
     cookies: &Cookies,
     macaroon: Option<HeaderValue>,
-) -> Result<String, StatusCode> {
+) -> Result<String, Response> {
     match macaroon {
         Some(macaroon) => {
             let res = macaroon
                 .to_str()
                 .map(|str| str.to_string())
-                .map_err(|_| StatusCode::UNAUTHORIZED);
+                .map_err(|_| (StatusCode::UNAUTHORIZED, "unauthorized").into_response());
             res
         }
         None => match cookies.get("macaroon") {
@@ -19,7 +20,7 @@ pub fn get_macaroon_hex_str_from_cookies_or_header(
                 let macaroon_cookie_str = macaroon_cookie.value().to_string();
                 Ok(macaroon_cookie_str)
             }
-            None => Err(StatusCode::UNAUTHORIZED),
+            None => Err((StatusCode::UNAUTHORIZED, "unauthorized").into_response()),
         },
     }
 }

--- a/web-admin/package-lock.json
+++ b/web-admin/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^1.4.2",
         "@heroicons/react": "^1.0.5",
-        "@l2-technology/sensei-client": "^0.1.20",
+        "@l2-technology/sensei-client": "0.1.22",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.4.0",
         "@tailwindcss/typography": "^0.5.0",
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/@l2-technology/sensei-client": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.20.tgz",
-      "integrity": "sha512-1zipy1YphCpa6gNQis/ZDrEaHrr+UML+ifCzeU7aZhSQf0UdViqlXD+aOI4+BQMAlBfb8j68L/x808pEN1khEQ=="
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.22.tgz",
+      "integrity": "sha512-QIBxCFwh/eUW2tMnv7XMFh3iEizubP2/H1rTNvXPPca+sn+mRTfwWO0zpBTMVgsPv0dDeQ+Kzvw4WnjJw2Pwww=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -25922,9 +25922,9 @@
       }
     },
     "@l2-technology/sensei-client": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.20.tgz",
-      "integrity": "sha512-1zipy1YphCpa6gNQis/ZDrEaHrr+UML+ifCzeU7aZhSQf0UdViqlXD+aOI4+BQMAlBfb8j68L/x808pEN1khEQ=="
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@l2-technology/sensei-client/-/sensei-client-0.1.22.tgz",
+      "integrity": "sha512-QIBxCFwh/eUW2tMnv7XMFh3iEizubP2/H1rTNvXPPca+sn+mRTfwWO0zpBTMVgsPv0dDeQ+Kzvw4WnjJw2Pwww=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.2",
     "@heroicons/react": "^1.0.5",
-    "@l2-technology/sensei-client": "^0.1.20",
+    "@l2-technology/sensei-client": "0.1.22",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/typography": "^0.5.0",

--- a/web-admin/src/channels/components/OpenChannelForm.tsx
+++ b/web-admin/src/channels/components/OpenChannelForm.tsx
@@ -3,6 +3,7 @@ import { Form, Input, Select } from "../../components/form";
 import { z } from "zod";
 import openChannel from "../mutations/openChannel";
 import { useSearchParams } from "react-router-dom";
+import { useError } from "src/contexts/error";
 
 export const OpenChannelInput = z.object({
   node_connection_string: z.string(),
@@ -11,6 +12,7 @@ export const OpenChannelInput = z.object({
 });
 
 const OpenChannelForm = () => {
+  const { showError } = useError();
   let navigate = useNavigate();
   let [searchParams, _setSearchParams] = useSearchParams();
   let initialConnectionString = searchParams.get("connection") || "";
@@ -33,14 +35,18 @@ const OpenChannelForm = () => {
       layout="default"
       onSubmit={async ({ node_connection_string, amt_sats, pub }) => {
         try {
-          await openChannel(
+          const result = await openChannel(
             node_connection_string,
             parseInt(amt_sats, 10),
             pub === "true"
           );
-          navigate("/admin/channels");
+          if(result.error) {
+            showError(result.errorMessage)
+          } else {
+            navigate("/admin/channels");
+          }
         } catch (e) {
-          // TODO: handle error
+          showError(e.message)
         }
       }}
     >


### PR DESCRIPTION
This fixes a bunch of issues around failure cases during channel opens.  It surfaces the errors back to the UI so the end-user can (hopefully) understand why a channel failed to open.  Before this there was often no feedback whatsoever and it either looked like the channel might still be opening or even worse the daemon would panic.

This also updates the return type to be the actual channel id of the channel instead of the temporary channel id since by the end of this flow the funding tx is known and broadcast.