### PR TITLE
fix graph persistence bug and add proper shutdown handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,6 +2903,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "signal-hook",
  "tokio",
  "tonic",
  "tonic-build",
@@ -3079,6 +3080,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tower-cookies = "0.4"
 dirs = "4.0"
 rust-embed="6.3.0"
 mime_guess = { version = "2" }
+signal-hook = "0.3.14"
 entity = { path = "entity" }
 migration = { path = "migration" }
 senseicore = { path = "senseicore" }

--- a/senseicore/src/persist.rs
+++ b/senseicore/src/persist.rs
@@ -165,7 +165,7 @@ impl SenseiPersister {
     }
 
     pub fn read_network_graph(&self) -> NetworkGraph {
-        if let Ok(Some(contents)) = self.store.read("network_graph") {
+        if let Ok(Some(contents)) = self.store.read("graph") {
             let mut cursor = Cursor::new(contents);
             if let Ok(graph) = NetworkGraph::read(&mut cursor, self.logger.clone()) {
                 return graph;


### PR DESCRIPTION
Fixed a couple issues here:

1) The network graph is persisted by the background processor but only every 10 minutes.  The only other time it is supposed to be persisted is on shutdown.  The big issue here is there was no proper shutdown handling in Sensei.  This means handling termination signals like SIGINT/SIGTERM/SIGQUIT and then gracefully shutting down.  This PR adds hooks for these signals, sets an AtomicBool / flag to true saying we've received signal to shutdown.  It then triggers proper shutdown of every running node, the p2p background processor (to persist graph/scorer), and chain manager.

2) There was a big typo where it was persisting the network graph with the key "network_graph" and reading it from the key "graph" causing it to never actually load the persisted graph on subsequent startups.  This also fixes that.