### PR TITLE
less precise logging timestamp on mainnet

### DIFF
--- a/senseicore/src/node.rs
+++ b/senseicore/src/node.rs
@@ -603,7 +603,7 @@ impl LightningNode {
 
         let bdk_wallet = Arc::new(Mutex::new(bdk_wallet));
 
-        let logger = Arc::new(FilesystemLogger::new(data_dir.clone()));
+        let logger = Arc::new(FilesystemLogger::new(data_dir.clone(), config.network));
 
         let broadcaster = Arc::new(SenseiBroadcaster::new(
             id.clone(),

--- a/senseicore/src/services/admin.rs
+++ b/senseicore/src/services/admin.rs
@@ -255,7 +255,10 @@ impl AdminService {
             }
         }
 
-        let logger = Arc::new(FilesystemLogger::new(String::from(data_dir)));
+        let logger = Arc::new(FilesystemLogger::new(
+            String::from(data_dir),
+            config.network,
+        ));
         let database = Arc::new(database);
         let config = Arc::new(config);
         let p2p = Arc::new(


### PR DESCRIPTION
For testing it's nice to have sub-second precision in logs.  In production this can be a potential attack vector.  This toggles the precision based on network.