### PR TITLE
add instance name

### DIFF
--- a/senseicore/src/config.rs
+++ b/senseicore/src/config.rs
@@ -31,6 +31,7 @@ pub struct SenseiConfig {
     pub remote_p2p_host: Option<String>,
     pub remote_p2p_token: Option<String>,
     pub gossip_peers: String,
+    pub instance_name: String,
 }
 
 impl Default for SenseiConfig {
@@ -53,6 +54,7 @@ impl Default for SenseiConfig {
             remote_p2p_host: None,
             remote_p2p_token: None,
             gossip_peers: String::from(""),
+            instance_name: String::from("sensei"),
         }
     }
 }

--- a/senseicore/src/p2p/mod.rs
+++ b/senseicore/src/p2p/mod.rs
@@ -71,7 +71,7 @@ impl SenseiP2P {
         runtime_handle: tokio::runtime::Handle,
         stop_signal: Arc<AtomicBool>,
     ) -> Self {
-        let p2p_node_id = "SENSEI".to_string();
+        let p2p_node_id = config.instance_name.clone();
 
         let persistence_store =
             AnyKVStore::Database(DatabaseStore::new(database.clone(), p2p_node_id.clone()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,8 @@ struct SenseiArgs {
     remote_p2p_host: Option<String>,
     #[clap(long, env = "REMOTE_P2P_TOKEN")]
     remote_p2p_token: Option<String>,
+    #[clap(long, env = "INSTANCE_NAME")]
+    instance_name: Option<String>,
 }
 
 pub type AdminRequestResponse = (AdminRequest, Sender<AdminResponse>);
@@ -169,6 +171,9 @@ fn main() {
     }
     if let Some(remote_p2p_token) = args.remote_p2p_token {
         config.remote_p2p_token = Some(remote_p2p_token);
+    }
+    if let Some(instance_name) = args.instance_name {
+        config.instance_name = instance_name;
     }
 
     if !config.database_url.starts_with("postgres:") && !config.database_url.starts_with("mysql:") {


### PR DESCRIPTION
This adds ability to set an instance name.  For now the only usage of this is for keying into the p2p node's key-value storage.