### PR TITLE
fix cors and add allow origins cli opt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.2.5",
  "tower-layer",
  "tower-service",
 ]
@@ -2950,7 +2950,7 @@ dependencies = [
  "tonic-build",
  "tower",
  "tower-cookies",
- "tower-http",
+ "tower-http 0.3.4",
 ]
 
 [[package]]
@@ -3826,6 +3826,25 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
  "httpdate",
  "mime",
  "mime_guess",
@@ -3833,7 +3852,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util 0.7.2",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ hyper = "0.14"
 clap = { version = "3.0", features = [ "derive", "env" ] }
 headers = "0.3"
 macaroon = "0.2"
-tower-http = { version = "0.2.5", features = ["fs", "trace", "cors"] }
+tower-http = { version = "0.3.4", features = ["fs", "trace", "cors"] }
 tower-cookies = "0.4"
 dirs = "4.0"
 rust-embed="6.3.0"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ MySQL Example: `--database-url=mysql://sensei:sensei@localhost:3306/sensei`
 
 In order to see your changes live you will need to:
 
-1. Run sensei in development mode: `cargo run --bin senseid -- --development-mode=true --network=regtest --bitcoind-rpc-host=localhost --bitcoind-rpc-port=18443 --bitcoind-rpc-username=admin1 --bitcoind-rpc-password=123`
+1. Allow requests from local web-admin: `cargo run --bin senseid -- --network=regtest --bitcoind-rpc-host=localhost --bitcoind-rpc-port=18443 --bitcoind-rpc-username=admin1 --bitcoind-rpc-password=123 --allow-origins=http://localhost:3001`
 2. Run the web-admin dev server: `cd sensei/web-admin && npm install && npm run start`
 3. Visit the admin using port 3001: `http://localhost:3001/admin/nodes`
 


### PR DESCRIPTION
Removes the 'development-mode' and the half-baked cors support.

This adds allow-origins cli opt for specifying origins that should be allowed to make requests to the server.  It allows credentials, mirrors headers, and mirrors methods but enforces a strict origin match.

This means by default it does not allow cross origin requests unless --allow-origins is used to whitelist origins.

When developing the web-admin you will need to allow requests from the development server --allow-origins=http://localhost:3001 or whatever port you are using to serve it from.