### PR TITLE
add support for rapid gossip sync

### DIFF
--- a/senseicore/src/p2p/background_processor.rs
+++ b/senseicore/src/p2p/background_processor.rs
@@ -6,29 +6,35 @@ use std::time::{Duration, Instant};
 use crate::node::{NetworkGraph, RoutingPeerManager};
 use crate::persist::SenseiPersister;
 
+use lightning_rapid_gossip_sync::RapidGossipSync;
+
 use super::router::AnyScorer;
 
 const PING_TIMER: u64 = 10;
 /// Prune the network graph of stale entries hourly.
 const NETWORK_PRUNE_TIMER: u64 = 60 * 60;
-const SCORER_PERSIST_TIMER: u64 = 30;
 const FIRST_NETWORK_PRUNE_TIMER: u64 = 60;
+const SCORER_PERSIST_TIMER: u64 = 30;
+const RAPID_GOSSIP_SYNC_TIMER: u64 = 60 * 60;
+const FIRST_RAPID_GOSSIP_SYNC_TIMER: u64 = 0;
 
 pub struct BackgroundProcessor {
-    peer_manager: Arc<RoutingPeerManager>,
+    peer_manager: Option<Arc<RoutingPeerManager>>,
     scorer: Arc<Mutex<AnyScorer>>,
     network_graph: Arc<NetworkGraph>,
     persister: Arc<SenseiPersister>,
     stop_signal: Arc<AtomicBool>,
+    rapid_gossip_sync_server_host: Option<String>,
 }
 
 impl BackgroundProcessor {
     pub fn new(
-        peer_manager: Arc<RoutingPeerManager>,
+        peer_manager: Option<Arc<RoutingPeerManager>>,
         scorer: Arc<Mutex<AnyScorer>>,
         network_graph: Arc<NetworkGraph>,
         persister: Arc<SenseiPersister>,
         stop_signal: Arc<AtomicBool>,
+        rapid_gossip_sync_server_host: Option<String>,
     ) -> Self {
         Self {
             peer_manager,
@@ -36,6 +42,7 @@ impl BackgroundProcessor {
             network_graph,
             persister,
             stop_signal,
+            rapid_gossip_sync_server_host,
         }
     }
 
@@ -43,14 +50,19 @@ impl BackgroundProcessor {
         let mut last_prune_call = Instant::now();
         let mut last_scorer_persist_call = Instant::now();
         let mut last_ping_call = Instant::now();
+        let mut last_rgs_sync_call = Instant::now();
         let mut have_pruned = false;
+        let mut have_rapid_gossip_synced = false;
         let mut interval = tokio::time::interval(Duration::from_millis(50));
         loop {
             interval.tick().await;
-            if last_ping_call.elapsed().as_secs() > PING_TIMER {
-                self.peer_manager.process_events();
-                self.peer_manager.timer_tick_occurred();
-                last_ping_call = Instant::now();
+
+            if let Some(peer_manager) = &self.peer_manager {
+                if last_ping_call.elapsed().as_secs() > PING_TIMER {
+                    peer_manager.process_events();
+                    peer_manager.timer_tick_occurred();
+                    last_ping_call = Instant::now();
+                }
             }
 
             // Note that we want to run a graph prune once not long after startup before
@@ -71,6 +83,56 @@ impl BackgroundProcessor {
 
                 last_prune_call = Instant::now();
                 have_pruned = true;
+            }
+
+            if let Some(rapid_gossip_sync_server_host) = &self.rapid_gossip_sync_server_host {
+                if last_rgs_sync_call.elapsed().as_secs()
+                    > if have_rapid_gossip_synced {
+                        RAPID_GOSSIP_SYNC_TIMER
+                    } else {
+                        FIRST_RAPID_GOSSIP_SYNC_TIMER
+                    }
+                {
+                    let rapid_sync = RapidGossipSync::new(self.network_graph.clone());
+                    let last_rapid_gossip_sync_timestamp = self
+                        .network_graph
+                        .get_last_rapid_gossip_sync_timestamp()
+                        .unwrap_or(0);
+                    let rapid_gossip_sync_uri = format!(
+                        "{}/snapshot/{}",
+                        rapid_gossip_sync_server_host, last_rapid_gossip_sync_timestamp
+                    );
+                    let update_data = match reqwest::get(&rapid_gossip_sync_uri).await {
+                        Ok(response) => {
+                            match response.bytes().await {
+                                Ok(bytes) => Some(bytes.to_vec()),
+                                Err(e) => {
+                                    eprintln!("failed to convert rapid gossip sync response to bytes: {:?}", e);
+                                    None
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "failed to fetch rapid gossip sync update at {} with error: {:?}",
+                                rapid_gossip_sync_uri, e
+                            );
+                            None
+                        }
+                    };
+
+                    if let Some(update_data) = update_data {
+                        if let Err(e) = rapid_sync.update_network_graph(&update_data[..]) {
+                            eprintln!(
+                                "failed to update network graph with rapid gossip sync data: {:?}",
+                                e
+                            );
+                        }
+                    }
+
+                    last_rgs_sync_call = Instant::now();
+                    have_rapid_gossip_synced = true;
+                }
             }
 
             if last_scorer_persist_call.elapsed().as_secs() > SCORER_PERSIST_TIMER {

--- a/senseicore/src/p2p/bubble_gossip_route_handler.rs
+++ b/senseicore/src/p2p/bubble_gossip_route_handler.rs
@@ -12,6 +12,7 @@ use super::router::RemoteSenseiInfo;
 pub enum AnyP2PGossipHandler {
     Remote(RemoteGossipMessageHandler),
     Local(NetworkGraphMessageHandler),
+    None,
 }
 
 impl AnyP2PGossipHandler {
@@ -29,6 +30,9 @@ impl MessageSendEventsProvider for AnyP2PGossipHandler {
             AnyP2PGossipHandler::Local(local_handler) => {
                 local_handler.get_and_clear_pending_msg_events()
             }
+            AnyP2PGossipHandler::None => {
+                vec![]
+            }
         }
     }
 }
@@ -41,6 +45,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
         match self {
             AnyP2PGossipHandler::Remote(handler) => handler.handle_node_announcement(msg),
             AnyP2PGossipHandler::Local(handler) => handler.handle_node_announcement(msg),
+            AnyP2PGossipHandler::None => {
+                panic!("handle_node_announcement called without a P2P Gossip Handler")
+            }
         }
     }
 
@@ -51,6 +58,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
         match self {
             AnyP2PGossipHandler::Remote(handler) => handler.handle_channel_announcement(msg),
             AnyP2PGossipHandler::Local(handler) => handler.handle_channel_announcement(msg),
+            AnyP2PGossipHandler::None => {
+                panic!("handle_channel_announcement called without a P2P Gossip Handler")
+            }
         }
     }
 
@@ -61,6 +71,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
         match self {
             AnyP2PGossipHandler::Remote(handler) => handler.handle_channel_update(msg),
             AnyP2PGossipHandler::Local(handler) => handler.handle_channel_update(msg),
+            AnyP2PGossipHandler::None => {
+                panic!("handle_channel_update called without a P2P Gossip Handler")
+            }
         }
     }
 
@@ -80,6 +93,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
             AnyP2PGossipHandler::Local(handler) => {
                 handler.get_next_channel_announcements(starting_point, batch_amount)
             }
+            AnyP2PGossipHandler::None => {
+                panic!("get_next_channel_announcements called without a P2P Gossip Handler")
+            }
         }
     }
 
@@ -95,6 +111,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
             AnyP2PGossipHandler::Local(handler) => {
                 handler.get_next_node_announcements(starting_point, batch_amount)
             }
+            AnyP2PGossipHandler::None => {
+                panic!("get_next_node_announcements called without a P2P Gossip Handler")
+            }
         }
     }
 
@@ -106,6 +125,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
         match self {
             AnyP2PGossipHandler::Remote(handler) => handler.peer_connected(their_node_id, init),
             AnyP2PGossipHandler::Local(handler) => handler.peer_connected(their_node_id, init),
+            AnyP2PGossipHandler::None => {
+                panic!("peer_connected called without a P2P Gossip Handler")
+            }
         }
     }
 
@@ -120,6 +142,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
             }
             AnyP2PGossipHandler::Local(handler) => {
                 handler.handle_reply_channel_range(their_node_id, msg)
+            }
+            AnyP2PGossipHandler::None => {
+                panic!("handle_reply_channel_range called without a P2P Gossip Handler")
             }
         }
     }
@@ -136,6 +161,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
             AnyP2PGossipHandler::Local(handler) => {
                 handler.handle_reply_short_channel_ids_end(their_node_id, msg)
             }
+            AnyP2PGossipHandler::None => {
+                panic!("handle_reply_short_channel_ids_end called without a P2P Gossip Handler")
+            }
         }
     }
 
@@ -151,6 +179,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
             AnyP2PGossipHandler::Local(handler) => {
                 handler.handle_query_channel_range(their_node_id, msg)
             }
+            AnyP2PGossipHandler::None => {
+                panic!("handle_query_channel_range called without a P2P Gossip Handler")
+            }
         }
     }
 
@@ -165,6 +196,9 @@ impl RoutingMessageHandler for AnyP2PGossipHandler {
             }
             AnyP2PGossipHandler::Local(handler) => {
                 handler.handle_query_short_channel_ids(their_node_id, msg)
+            }
+            AnyP2PGossipHandler::None => {
+                panic!("handle_query_short_channel_ids called without a P2P Gossip Handler")
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,8 @@ struct SenseiArgs {
     poll_for_chain_updates: Option<bool>,
     #[clap(long, env = "ALLOW_ORIGINS")]
     allow_origins: Option<Vec<String>>,
+    #[clap(long, env = "RAPID_GOSSIP_SYNC_SERVER_HOST")]
+    rapid_gossip_sync_server_host: Option<String>,
 }
 
 pub type AdminRequestResponse = (AdminRequest, Sender<AdminResponse>);
@@ -199,6 +201,9 @@ fn main() {
     }
     if let Some(poll_for_chain_updates) = args.poll_for_chain_updates {
         config.poll_for_chain_updates = poll_for_chain_updates
+    }
+    if let Some(rapid_gossip_sync_server_host) = args.rapid_gossip_sync_server_host {
+        config.rapid_gossip_sync_server_host = Some(rapid_gossip_sync_server_host)
     }
 
     if !config.database_url.starts_with("postgres:") && !config.database_url.starts_with("mysql:") {


### PR DESCRIPTION
This adds a cli argument `--rapid-gossip-sync-server-host` that when set will disable the default p2p routing peer manager and manage the network graph via rapid gossip sync.  It will poll once an hour for updates.