### PR TITLE
generate ldk seed from bip32 master priv key

### DIFF
--- a/senseicore/src/database.rs
+++ b/senseicore/src/database.rs
@@ -622,44 +622,58 @@ impl SenseiDatabase {
         })
     }
 
-    pub async fn get_seed(&self, node_id: String) -> Result<Option<Vec<u8>>, Error> {
-        self.get_value(node_id, String::from("seed"))
+    pub async fn get_entropy(&self, node_id: String) -> Result<Option<Vec<u8>>, Error> {
+        self.get_value(node_id, String::from("entropy"))
             .await
             .map(|model| model.map(|model| model.v))
     }
 
-    pub fn get_seed_sync(&self, node_id: String) -> Result<Option<Vec<u8>>, Error> {
+    pub fn get_entropy_sync(&self, node_id: String) -> Result<Option<Vec<u8>>, Error> {
         tokio::task::block_in_place(move || {
             self.runtime_handle
-                .block_on(async move { self.get_seed(node_id).await })
+                .block_on(async move { self.get_entropy(node_id).await })
         })
     }
 
-    pub async fn set_seed(&self, node_id: String, seed: Vec<u8>) -> Result<kv_store::Model, Error> {
-        self.set_value(node_id, String::from("seed"), seed).await
-    }
-
-    pub fn set_seed_sync(&self, node_id: String, seed: Vec<u8>) -> Result<kv_store::Model, Error> {
-        tokio::task::block_in_place(move || {
-            self.runtime_handle
-                .block_on(async move { self.set_seed(node_id, seed).await })
-        })
-    }
-
-    pub async fn create_seed(
+    pub async fn set_entropy(
         &self,
         node_id: String,
-        seed: Vec<u8>,
+        entropy: Vec<u8>,
     ) -> Result<kv_store::Model, Error> {
-        self.create_value(node_id, String::from("seed"), seed).await
+        self.set_value(node_id, String::from("entropy"), entropy)
+            .await
     }
 
-    pub fn get_seed_active_model(&self, node_id: String, seed: Vec<u8>) -> kv_store::ActiveModel {
+    pub fn set_entropy_sync(
+        &self,
+        node_id: String,
+        entropy: Vec<u8>,
+    ) -> Result<kv_store::Model, Error> {
+        tokio::task::block_in_place(move || {
+            self.runtime_handle
+                .block_on(async move { self.set_entropy(node_id, entropy).await })
+        })
+    }
+
+    pub async fn create_entropy(
+        &self,
+        node_id: String,
+        entropy: Vec<u8>,
+    ) -> Result<kv_store::Model, Error> {
+        self.create_value(node_id, String::from("entropy"), entropy)
+            .await
+    }
+
+    pub fn get_entropy_active_model(
+        &self,
+        node_id: String,
+        entropy: Vec<u8>,
+    ) -> kv_store::ActiveModel {
         let now = seconds_since_epoch();
         kv_store::ActiveModel {
             node_id: ActiveValue::Set(node_id),
-            k: ActiveValue::Set(String::from("seed")),
-            v: ActiveValue::Set(seed),
+            k: ActiveValue::Set(String::from("entropy")),
+            v: ActiveValue::Set(entropy),
             created_at: ActiveValue::Set(now),
             updated_at: ActiveValue::Set(now),
             ..Default::default()

--- a/senseicore/src/error.rs
+++ b/senseicore/src/error.rs
@@ -28,8 +28,9 @@ pub enum Error {
     LdkInvoiceSign(lightning_invoice::SignOrCreationError),
     LdkInvoiceParse(lightning_invoice::ParseOrSemanticError),
     InvalidSeedLength,
-    FailedToWriteSeed,
-    SeedNotFound,
+    InvalidEntropyLength,
+    FailedToWriteEntropy,
+    EntropyNotFound,
     MacaroonNotFound,
     Unauthenticated,
     InvalidMacaroon,
@@ -57,9 +58,9 @@ impl Display for Error {
             Error::LdkInvoiceSign(e) => e.to_string(),
             Error::LdkInvoiceParse(e) => e.to_string(),
             Error::InvalidSeedLength => String::from("invalid seed length"),
-            Error::SeedNotFound => String::from("seed not found for node"),
+            Error::EntropyNotFound => String::from("entropy not found for node"),
             Error::MacaroonNotFound => String::from("macaroon not found for node"),
-            Error::FailedToWriteSeed => String::from("failed to write seed"),
+            Error::FailedToWriteEntropy => String::from("failed to write entropy"),
             Error::Unauthenticated => String::from("unauthenticated"),
             Error::InvalidMacaroon => String::from("invalid macaroon"),
             Error::AdminNodeNotCreated => String::from("admin node not created"),
@@ -71,6 +72,7 @@ impl Display for Error {
             Error::ChannelOpenRejected(reason) => {
                 format!("Channel open rejected by peer: {:?}", reason)
             }
+            Error::InvalidEntropyLength => String::from("invalid entropy length"),
         };
         write!(f, "{}", str)
     }

--- a/senseicore/tests/smoke_test.rs
+++ b/senseicore/tests/smoke_test.rs
@@ -624,7 +624,7 @@ mod test {
     }
 
     async fn smoke_test(bitcoind: BitcoinD, admin_service: AdminService) {
-        let admin_token = create_admin_account(&admin_service, "admin", "admin").await;
+        let _admin_token = create_admin_account(&admin_service, "admin", "admin").await;
         let alice = create_node(&admin_service, "alice", "alice", true).await;
         let bob = create_node(&admin_service, "bob", "bob", true).await;
         let charlie = create_node(&admin_service, "charlie", "charlie", true).await;
@@ -732,7 +732,7 @@ mod test {
     }
 
     async fn batch_open_channels_test(bitcoind: BitcoinD, admin_service: AdminService) {
-        let admin_token = create_admin_account(&admin_service, "admin", "admin").await;
+        let _admin_token = create_admin_account(&admin_service, "admin", "admin").await;
         let alice = create_node(&admin_service, "alice", "alice", true).await;
         let bob = create_node(&admin_service, "bob", "bob", true).await;
         let charlie = create_node(&admin_service, "charlie", "charlie", true).await;


### PR DESCRIPTION
This allows us to use 12 or 24 word mnemonics with or without a passphrase and still get 32 bytes for our ldk seed used in the KeysManager.

Still need to implement bip39 and a recovery flow.